### PR TITLE
fix TypeScript typings for query* selectors

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 2.8
 
 import {
-  SelectorMatcherOptions,
+  SelectorMatcherOptions as DTLSelectorMatcherOptions,
   Matcher,
   MatcherOptions as DTLMatcherOptions,
   getByTestId,
@@ -12,6 +12,7 @@ export interface CTLMatcherOptions {
 }
 
 export type MatcherOptions = DTLMatcherOptions | CTLMatcherOptions
+export type SelectorMatcherOptions = DTLSelectorMatcherOptions | CTLMatcherOptions
 
 declare global {
   namespace Cypress {


### PR DESCRIPTION
Simply created a PR based on the changes ShimiTheFirst suggested here https://github.com/testing-library/cypress-testing-library/issues/43



<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: add typings for queryByText and other query* selectors missing the cypress option *timeout: 1000*

<!-- Why are these changes necessary? -->

**Why**: typings were missing causing TS to throw an error



<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A (documents itself as it's TS typings)
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
