### PR TITLE
📝 Add correct README instructions for tsconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ added as follows in `tsconfig.json`:
   }
 }
 ```
+or if tsconfig.json has a `baseUrl` of `../node_modules` as recommended in the official Cypress documentation use:
+```json
+{
+  "compilerOptions": {
+    "types": ["cypress", "@testing-library/cypress/typings"]
+  }
+}
+```
 
 ## Usage
 
@@ -101,6 +109,8 @@ import '@testing-library/cypress/add-commands';
 You can now use all of `dom-testing-library`'s `getBy`, `getAllBy`, `queryBy`
 and `queryAllBy` commands.
 [See the `dom-testing-library` docs for reference](https://testing-library.com)
+
+You can find [all Library definitions here](./typings/index.d.ts).
 
 To show some simple examples (from
 [cypress/integration/commands.spec.js](cypress/integration/commands.spec.js)):

--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ added as follows in `tsconfig.json`:
   }
 }
 ```
-or if tsconfig.json has a `baseUrl` of `../node_modules` as recommended in the official Cypress documentation use:
+
+Or if tsconfig.json has a `baseUrl` of `../node_modules` as recommended in
+the official Cypress documentation use:
+
 ```json
 {
   "compilerOptions": {


### PR DESCRIPTION
Edited README only.

Why?
I followed the instructions and it didn't work with recent changes to official instructions from Cypress-typescript I installed last week. So these documentation will help out anyone doing this today.

I also found the types file to be handy for all library definitions, so I added it into the README

