### PR TITLE
Fix TypeScript casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This allows you to use all the useful
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Installation](#installation)
-  - [With typescript](#with-typescript)
+  - [With TypeScript](#with-typescript)
 - [Usage](#usage)
 - [Other Solutions](#other-solutions)
 - [Contributors](#contributors)
@@ -75,7 +75,7 @@ should be installed as one of your project's `devDependencies`:
 npm install --save-dev @testing-library/cypress
 ```
 
-### With typescript
+### With TypeScript
 
 Typings are defined under `@testing-library/cypress/typings`, and should be
 added as follows in `tsconfig.json`:


### PR DESCRIPTION
Hey there, thanks for this library! Just ran across it now.

Just a quick PR to update the casing of TypeScript.

**What**:

Casing for "TypeScript" has been updated.

**Why**:

It was lowercase.

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged
