### PR TITLE
fix(TS): Cypress commands return jQuery objects (#58)

### DIFF
--- a/tests/typescript-types/test.spec.ts
+++ b/tests/typescript-types/test.spec.ts
@@ -1,6 +1,11 @@
 test('includes proper TypeScript types', () => {
   cy.visit('#/foo')
 
+  cy.getByLabelText('foo').should($elements => {
+    expect($elements.length).to.eq(0)
+    expect($elements[0].tagName).to.eq(0)
+  })
+
   cy.getAllByPlaceholderText('foo').should($elements => {
     expect($elements.length).to.eq(0)
     expect($elements[0].tagName).to.eq(0)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,11 +1,6 @@
 // TypeScript Version: 2.8
 
-import {
-  SelectorMatcherOptions as DTLSelectorMatcherOptions,
-  Matcher,
-  MatcherOptions as DTLMatcherOptions,
-  getByTestId,
-} from '@testing-library/dom'
+import { Matcher, MatcherOptions as DTLMatcherOptions, SelectorMatcherOptions as DTLSelectorMatcherOptions } from '@testing-library/dom';
 
 export interface CTLMatcherOptions {
   timeout?: number
@@ -153,11 +148,11 @@ declare global {
       getBySelectText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<E>
+      ): Chainable<JQuery<E>>
       getBySelectText<K extends keyof HTMLElementTagNameMap>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<HTMLElementTagNameMap[K]>
+      ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -233,11 +228,11 @@ declare global {
       getByText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: SelectorMatcherOptions,
-      ): Chainable<E>
+      ): Chainable<JQuery<E>>
       getByText<K extends keyof HTMLElementTagNameMap>(
         id: Matcher,
         options?: SelectorMatcherOptions,
-      ): Chainable<HTMLElementTagNameMap[K]>
+      ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -313,11 +308,11 @@ declare global {
       getByLabelText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: SelectorMatcherOptions,
-      ): Chainable<E>
+      ): Chainable<JQuery<E>>
       getByLabelText<K extends keyof HTMLElementTagNameMap>(
         id: Matcher,
         options?: SelectorMatcherOptions,
-      ): Chainable<HTMLElementTagNameMap[K]>
+      ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -393,11 +388,11 @@ declare global {
       getByAltText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<E>
+      ): Chainable<JQuery<E>>
       getByAltText<K extends keyof HTMLElementTagNameMap>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<HTMLElementTagNameMap[K]>
+      ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -473,11 +468,11 @@ declare global {
       getByTestId<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<E>
+      ): Chainable<JQuery<E>>
       getByTestId<K extends keyof HTMLElementTagNameMap>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<HTMLElementTagNameMap[K]>
+      ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -553,11 +548,11 @@ declare global {
       getByTitle<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<E>
+      ): Chainable<JQuery<E>>
       getByTitle<K extends keyof HTMLElementTagNameMap>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<HTMLElementTagNameMap[K]>
+      ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -633,11 +628,11 @@ declare global {
       getByDisplayValue<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<E>
+      ): Chainable<JQuery<E>>
       getByDisplayValue<K extends keyof HTMLElementTagNameMap>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<HTMLElementTagNameMap[K]>
+      ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -713,11 +708,11 @@ declare global {
       getByRole<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<E>
+      ): Chainable<JQuery<E>>
       getByRole<K extends keyof HTMLElementTagNameMap>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<HTMLElementTagNameMap[K]>
+      ): Chainable<JQuery<HTMLElementTagNameMap[K]>>
 
       /**
        * dom-testing-library helpers for Cypress


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Some functions have not the right typings. I started from the `getByLabelText` function to discover that the bug affects all the following functions
```
getByAltText
getByDisplayValue
getByLabelText
getByRole
getBySelectText
getByTestId
getByText
getByTitle
```
@aaronmcadam (partially) fixed it in #56 but the functions above were left untouched. @aaronmcadam I'm not sure why you have not fixed the above functions too. 

**Why**:
Because you can not consume the `getByLabelText` etc. functions with the right/expected flow
![Screen Shot 2019-07-19 at 13 59 04](https://user-images.githubusercontent.com/173663/61534894-142b1d00-aa31-11e9-9a8d-41769633892f.png)

**How**:

To be sure that I'm making the correct thing I proceeded this way:
- accordingly to the actual typing, the above functions should return standard HTML elements, I've asserted that adding
```javascript
.then($el => {
   expect(Cypress.dom.isJquery($el)).to.eq(false);
})
```
to the existing tests.
![Screen Shot 2019-07-19 at 13 57 01](https://user-images.githubusercontent.com/173663/61534913-21e0a280-aa31-11e9-86fa-d1e80a306c63.png)

- the tests fail

![Screen Shot 2019-07-19 at 13 57 08](https://user-images.githubusercontent.com/173663/61535012-6b30f200-aa31-11e9-973e-fc00507837e8.png)
- then, I reverted the assertion and they succeed. I'm now sure that the returned subject is a jQuery instance.

So, I have updated the typings file and I've added one more TS test.

**Checklist**:

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

Fixes #58

Thank you for the amazing library ❤️
