### PR TITLE
Ensure higher version of dom is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@testing-library/dom": "^5.0.1"
+    "@testing-library/dom": "^5.6.0"
   },
   "devDependencies": {
     "@types/jquery": "*",


### PR DESCRIPTION
Updated the package version of @testing-library/dom

**What**:

Increased the minimum version of the @testing-library/dom dependency for the project

**Why**:

To ensure we Cypress related fixes for setImmediate are included when being used

**How**:

Updated package.json

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged
  