### PR TITLE
Update tsconfig example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ npm install --save-dev @testing-library/cypress
 
 ### With TypeScript
 
-Typings are defined in `@types/testing-library__cypress` at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__cypress),
-and should be added as follows in `tsconfig.json`:
+Typings are defined in `@types/testing-library__cypress` at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__cypress).
+It is a dependency for this library, so it can be added as
+follows in `tsconfig.json`:
 
 ```json
 {
   "compilerOptions": {
-    "types": ["cypress", "@types/testing-library__cypress"]
+    "types": ["cypress", "@testing-library/cypress"]
   }
 }
 ```


### PR DESCRIPTION
Update `tsconfig.json` in README to reflect that `@types/testing-library__cypress` is a dependency, and should not have to be installed by the user.
