### PR TITLE
Expose @testing-library/dom#configure to support configuring the `testIdAttribute`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {queries, waitForElement} from '@testing-library/dom'
+import {configure, queries, waitForElement} from '@testing-library/dom'
 import {getContainer} from './utils'
 
 const getDefaultCommandOptions = () => {
@@ -73,7 +73,7 @@ const commands = Object.keys(queries).map(queryName => {
   }
 })
 
-export {commands}
+export {commands, configure}
 
 /* eslint no-new-func:0, complexity:0 */
 /* globals Cypress, cy */


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

We should be able to configure the library [using the same `configure` function as provided by `@testing-library/dom`](https://testing-library.com/docs/dom-testing-library/api-configuration).

**Why**:

<!-- How were these changes implemented? -->

I'm currently working at an organisation in which the components all use a custom test id attribute.

**How**:

<!-- Have you done all of these things?  -->

I exported `@testing-library/dom#configure` from the `index.js`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
