### PR TITLE
findBy* retry-ability when multiple elements found

### DIFF
--- a/cypress/fixtures/test-app/index.html
+++ b/cypress/fixtures/test-app/index.html
@@ -86,6 +86,13 @@
     <button onclick="this.innerText = 'Jackie Kicked'">Jackie Chan 2</button>
   </section>
   <section>
+    <h2>Remove element from DOM delayed</h2>
+    <ul>
+      <li>List Item</li>
+      <li>List Item <button onclick="li = this.parentElement; setTimeout(function() { li.remove(); }, 100)">Remove Parent</button></li>
+    </ul>
+  </section>
+  <section>
     <h2>*ByText on another page</h2>
     <a onclick='setTimeout(function() { window.location = "/next-page.html"; }, 100);'>Next Page</a>
   </section>

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -89,6 +89,11 @@ describe('find* dom-testing-library commands', () => {
     cy.findByText('Non-existing Button Text', {timeout: 100}).should('not.exist')
   })
 
+  it('findByText retry if multiple elements found', () => {
+    cy.findByText('Remove Parent').click()
+    cy.findByText('List Item', {timeout: 200}).should('exist')
+  })
+
   it('findByText within', () => {
     cy.get('#nested').within(() => {
       cy.findByText('Button Text 2').click()

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -123,12 +123,12 @@ describe('find* dom-testing-library commands', () => {
   })
 
   it('findByText finding multiple items should error', () => {
-    const errorMessage = `Found multiple elements with the text: /^Button Text/i\n\n(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).`
+    const errorMessage = `Timed out retrying: Expected to find element: 'findByText(/^Button Text/i)', but never found it.`
     cy.on('fail', err => {
       expect(err.message).to.eq(errorMessage)
     })
 
-    cy.findByText(/^Button Text/i)
+    cy.findByText(/^Button Text/i, { timeout: 100 })
   })
 })
 


### PR DESCRIPTION
**What:**

Add retry-ability to findBy* when multiple elements are matched.

**Why:**

findBy* queries would fail early if they match multiple elements, when it could automatically retry.

**How:*

This catches the multiple matches exception, and retries until the request times out.

**Checklist:**

[ ] Documentation
[x] Tests
[x] Ready to be merged

**Side Effects**

Unfortunately this change comes with side effects, in that the error message when this scenario occurs says that the element cannot be found. See the last commit for the new error message being expected in the test.

I can't see a way around that for now, and as such I'm not sure if we should include this change.

I thought I'd commit this PR so that others could see it, and consider another way of doing it.