### PR TITLE
Reintroduce timeout on the outer command then chain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ function createCommand(queryName, implementationName) {
 
       return cy
         .window({log: false})
-        .then((thenArgs) => {
+        .then({timeout: waitOptions.timeout + 100}, (thenArgs) => {
           const getValue = () => {
             const value = commandImpl(thenArgs.document);
             const result = Cypress.$(value);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes #89 and maybe #37 

**Why**:

There was a regression in ab5263d that removed the timeout from the promise chain.

**How**:

I reintroduced the timeout.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
