### PR TITLE
docs: Fix broken link to tests in usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ and `queryAllBy` commands.
 You can find [all Library definitions here](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__cypress/index.d.ts).
 
 To show some simple examples (from
-[cypress/integration/commands.spec.js](cypress/integration/commands.spec.js)):
+[cypress/integration/query.spec.js](cypress/integration/query.spec.js) or [cypress/integration/find.spec.js](cypress/integration/find.spec.js)):
 
 ```javascript
 cy.findAllByText('Jackie Chan').click()


### PR DESCRIPTION
Hi 👋 ,

Thank you for your work 👍 

**What**:

There is a broken link in the usage section.

**Why**:

The test file doesn't exist anymore.

**How**:

I changed the old link into two links pointing to the find and query test files.

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
