### PR TITLE
chore: remove uneeded dependencies and simplify setup

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,3 @@
 {
-  "baseUrl": "http://localhost:13370",
   "video": false
 }

--- a/cypress/fixtures/test-app/index.html
+++ b/cypress/fixtures/test-app/index.html
@@ -26,7 +26,7 @@
     <h2>*ByLabel and *ByPlaceholder</h2>
     <label for="by-text-input">Label 1</label>
     <input type="text" placeholder="Input 1" id="by-text-input" />
-    
+
     <label for="by-text-input-2">Label 2</label>
     <input type="text" placeholder="Input 2" id="by-text-input-2" />
   </section>
@@ -41,7 +41,7 @@
   <section>
     <h2>*ByDisplayValue</h2>
     <input type="text" value="Display Value 1" />
-    
+
     <input type="text" value="Display Value 2" />
   </section>
   <section>
@@ -87,7 +87,7 @@
   </section>
   <section>
     <h2>*ByText on another page</h2>
-    <a onclick='setTimeout(function() { window.location = "/next-page.html"; }, 100);'>Next Page</a>
+    <a onclick='setTimeout(function() { window.location = "/cypress/fixtures/test-app/next-page.html"; }, 100);'>Next Page</a>
   </section>
 <!-- Prettier unindents the script tag below -->
 <script>

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -1,6 +1,6 @@
 describe('find* dom-testing-library commands', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visit('cypress/fixtures/test-app/')
   })
 
   // Test each of the types of queries: LabelText, PlaceholderText, Text, DisplayValue, AltText, Title, Role, TestId

--- a/cypress/integration/get.spec.js
+++ b/cypress/integration/get.spec.js
@@ -1,6 +1,6 @@
 describe('get* queries should error', () => {
     beforeEach(() => {
-        cy.visit('/')
+        cy.visit('cypress/fixtures/test-app/')
     })
 
     const queryPrefixes = ['By', 'AllBy']

--- a/cypress/integration/query.spec.js
+++ b/cypress/integration/query.spec.js
@@ -1,6 +1,6 @@
 describe('query* dom-testing-library commands', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visit('cypress/fixtures/test-app/')
   })
 
   // Test each of the types of queries: LabelText, PlaceholderText, Text, DisplayValue, AltText, Title, Role, TestId
@@ -30,7 +30,7 @@ describe('query* dom-testing-library commands', () => {
       .click()
       .should('contain', 'Button Clicked')
   })
-  
+
   it('queryAllByText', () => {
     cy.queryAllByText(/^Button Text \d$/)
       .should('have.length', 2)
@@ -44,7 +44,7 @@ describe('query* dom-testing-library commands', () => {
       .clear()
       .type('Some new text')
   })
-  
+
   it('queryAllByDisplayValue', () => {
     cy.queryAllByDisplayValue(/^Display Value \d$/)
       .should('have.length', 2)

--- a/package.json
+++ b/package.json
@@ -12,11 +12,10 @@
     "test": "npm-run-all --parallel test:unit test:cypress",
     "test:unit": "kcd-scripts test --no-watch",
     "test:unit:watch": "kcd-scripts test",
-    "test:cypress:serve": "serve --listen 13370 ./cypress/fixtures/test-app",
-    "test:cypress:run": "wait-port --timeout 10000 localhost:13370 && cypress run",
+    "test:cypress:run": "cypress run",
     "test:cypress:open": "cypress open",
-    "test:cypress": "npm-run-all --silent --parallel --race test:cypress:serve test:cypress:run",
-    "test:cypress:dev": "npm-run-all --silent --parallel --race test:cypress:serve test:cypress:open",
+    "test:cypress": "npm run test:cypress:run",
+    "test:cypress:dev": "test:cypress:open",
     "validate": "kcd-scripts validate build,lint,test",
     "setup": "npm install && npm run validate -s"
   },
@@ -49,9 +48,7 @@
   "devDependencies": {
     "cypress": "3.4.1",
     "kcd-scripts": "^1.5.2",
-    "npm-run-all": "^4.1.2",
-    "serve": "^11.1.0",
-    "wait-port": "^0.2.2"
+    "npm-run-all": "^4.1.2"
   },
   "peerDependencies": {
     "cypress": "^2.1.0 || ^3.0.0"


### PR DESCRIPTION
**What**:

Removing `wait-on` and `serve` as dependencies

**Why**:

Cypress starts it's own server. The `fixtures` file can be accessed by `cy.visit('cypress/fixtures')`. This simplifies the dev experience by not requiring a web server to be maintained or risk port collisions.

**How**:

Removed dependencies, updated scripts and updated URLs called in test files and HTML files

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

New formatting must have been added as a pre-commit hook. I disabled them to avoid a noisy pull request