### PR TITLE
fix: remove extra command log message for get* queries

### DIFF
--- a/cypress/integration/get.spec.js
+++ b/cypress/integration/get.spec.js
@@ -19,6 +19,23 @@ describe('get* queries should error', () => {
 
                 cy[`${obsoleteQueryName}`]('Irrelevant')
             })
+
+            it(`${obsoleteQueryName} should not log more than once`, () => {
+
+                let logCount = 0
+                cy.on('log:added', (attrs, log) => {
+                    if (log.get('name') === obsoleteQueryName) {
+                        logCount = logCount + 1
+                    }
+                })
+
+                cy.on('fail', _ => {
+                    expect(logCount).to.equal(1)
+                    cy.removeAllListeners('log:added')
+                })
+
+                cy[`${obsoleteQueryName}`]('Irrelevant')
+            })
         })
     })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,6 @@ const getCommands = getQueryNames.map(queryName => {
   return {
     name: queryName,
     command: () => {
-      Cypress.log({
-        name: queryName,
-      })
-
       throw new Error(
         `You used '${queryName}' which has been removed from Cypress Testing Library because it does not make sense in this context. Please use '${queryName.replace(
           getRegex,


### PR DESCRIPTION
Related to #103

**What**:

Removing extra log message for `get*` queries.

Before:
<img width="531" alt="Screen Shot 2020-01-29 at 3 06 00 PM" src="https://user-images.githubusercontent.com/338257/73402585-db56e500-42aa-11ea-8a90-6235756d7987.png">

After:
<img width="530" alt="Screen Shot 2020-01-29 at 3 06 50 PM" src="https://user-images.githubusercontent.com/338257/73402599-e3168980-42aa-11ea-8dd5-4e16341e3a61.png">

**Why**:

It isn't really a big deal, but it is a bit distracting seeing the log message multiple times - once as a spinner (Cypress thinks the log is still pending because the error prevented it from closing) and once as an error line.

**How**:

I removed the `Cypress.log`. Logs usually need an `.end()` to tell Cypress when the log is closed since Cypress commands are asynchronous. Cypress is already logging errors in commands for us, so we don't need to log as well.

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
