### PR TITLE
feat: add more helpful debugging information to queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ and `queryAllBy` commands.
 
 You can find [all Library definitions here](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__cypress/index.d.ts).
 
-To configure DOM Testing Library, use the following:
+To configure DOM Testing Library, use the following custom command:
+
 ```javascript
 cy.configureCypressTestingLibrary(config)
 ```

--- a/README.md
+++ b/README.md
@@ -109,23 +109,48 @@ To show some simple examples (from
 [cypress/integration/query.spec.js](cypress/integration/query.spec.js) or [cypress/integration/find.spec.js](cypress/integration/find.spec.js)):
 
 ```javascript
-cy.queryByText('Button Text').should('exist')
-cy.queryByText('Non-existing Button Text').should('not.exist')
-cy.queryByLabelText('Label text', {timeout: 7000}).should('exist')
+cy.queryAllByText('Button Text').should('exist')
+cy.queryAllByText('Non-existing Button Text').should('not.exist')
+cy.queryAllByLabelText('Label text', {timeout: 7000}).should('exist')
 cy.findAllByText('Jackie Chan').click({multiple: true})
+
+// findAllByText _inside_ a form element
 cy.get('form').within(() => {
-  cy.findByText('Button Text').should('exist')
+  cy.findAllByText('Button Text').should('exist')
 })
 cy.get('form').then(subject => {
-  cy.findByText('Button Text', {container: subject}).should('exist')
+  cy.findAllByText('Button Text', {container: subject}).should('exist')
 })
+cy.get('form').findAllByText('Button Text').should('exist')
 ```
+
+### Differences DOM Testing Library
 
 `Cypress Testing Library` supports both jQuery elements and DOM nodes. This is
 necessary because Cypress uses jQuery elements, while `DOM Testing Library`
 expects DOM nodes. When you pass a jQuery element as `container`, it will get
 the first DOM node from the collection and use that as the `container` parameter
 for the `DOM Testing Library` functions.
+
+`get*` queries are disabled. `find*` queries do not use the Promise API of
+`DOM Testing Library`, but instead forward to the `get*` queries and use Cypress'
+built-in retryability using error messages from `get*` APIs to forward as error
+messages if a query fails. `query*` also uses `get*` APIs, but disables retryability.
+
+`findBy*` is less useful in Cypress compared to `findAllBy*`. If you intend to limit
+to only 1 element, the following will work:
+
+```javascript
+cy.findAllByText('Some Text').should('have.length', 1)
+```
+
+Cypress handles actions when there is only one element found. For example, the following
+will work without having to limit to only 1 returned element. The `cy.click` will
+automatically fail if more than 1 element is returned by the `findAllByText`:
+
+```javascript
+cy.findAllByText('Some Text').click()
+```
 
 ## Other Solutions
 

--- a/README.md
+++ b/README.md
@@ -144,12 +144,10 @@ built-in retryability using error messages from `get*` APIs to forward as error
 messages if a query fails. `query*` also uses `get*` APIs, but disables retryability.
 
 `findAll*` can select more than one element and is closer in functionality to how
-Cypress built-in commands work. is less useful in Cypress compared to `findAllBy*`. If you intend to limit
-to only 1 element, the following will work:
-
-```javascript
-cy.findAllByText('Some Text').should('have.length', 1)
-```
+Cypress built-in commands work. `findAll*` is preferred to `find*` queries.
+`find*` commands will fail if more than one element is found that matches the criteria
+which is not how built-in Cypress commands work, but is provided for closer compatibility
+to other Testing Libraries.
 
 Cypress handles actions when there is only one element found. For example, the following
 will work without having to limit to only 1 returned element. The `cy.click` will
@@ -157,6 +155,14 @@ automatically fail if more than 1 element is returned by the `findAllByText`:
 
 ```javascript
 cy.findAllByText('Some Text').click()
+```
+
+If you intend to enforce only 1 element is returned by a selector, the following
+examples will both fail if more than one element is found.
+
+```javascript
+cy.findAllByText('Some Text').should('have.length', 1)
+cy.findByText('Some Text').should('exist')
 ```
 
 ## Other Solutions

--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "max-lines-per-function": "off",
+    "jest/valid-expect-in-promise": "off"
+  }
+}

--- a/cypress/fixtures/test-app/index.html
+++ b/cypress/fixtures/test-app/index.html
@@ -29,6 +29,9 @@
 
     <label for="by-text-input-2">Label 2</label>
     <input type="text" placeholder="Input 2" id="by-text-input-2" />
+
+    <p>Intentionally inaccessible label for error checking</p>
+    <label>Label 3</label>
   </section>
   <section>
     <h2>*ByText</h2>
@@ -88,6 +91,24 @@
   <section>
     <h2>*ByText on another page</h2>
     <a onclick='setTimeout(function() { window.location = "/cypress/fixtures/test-app/next-page.html"; }, 100);'>Next Page</a>
+  </section>
+  <section>
+    <h2>Eventual existence</h2>
+    <button id="eventually-will-exist"></button>
+    <script>
+      setTimeout(() => {
+        document.querySelector('#eventually-will-exist').innerHTML = 'Eventually Exists'
+      }, 500)
+    </script>
+  </section>
+  <section>
+    <h2>Eventual non-existence</h2>
+    <button id="eventually-will-not-exist">Eventually not exists</button>
+    <script>
+      setTimeout(() => {
+        document.querySelector('#eventually-will-not-exist').remove()
+      }, 500)
+    </script>
   </section>
 <!-- Prettier unindents the script tag below -->
 <script>

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -110,15 +110,28 @@ describe('find* dom-testing-library commands', () => {
     )
   })
 
+  it('findByText with a previous subject', () => {
+    cy.get('#nested')
+      .findByText('Button Text 1', { fallbackToPreviousFunctionality: false })
+      .should('not.exist')
+    cy.get('#nested')
+      .findByText('Button Text 2')
+      .should('exist')
+  })
+
   it('findByText within', () => {
     cy.get('#nested').within(() => {
-      cy.findByText('Button Text 2').click()
+      cy.findByText('Button Text 1').should('not.exist')
+      cy.findByText('Button Text 2').should('exist')
     })
   })
 
   it('findByText in container', () => {
-    return cy.get('#nested').then(subject => {
-      cy.findByText(/^Button Text/, {container: subject}).click()
+    // NOTE: Cypress' `then` doesn't actually return a promise
+    // eslint-disable-next-line jest/valid-expect-in-promise
+    cy.get('#nested').then(subject => {
+      cy.findByText('Button Text 1', {container: subject}).should('not.exist')
+      cy.findByText('Button Text 2', {container: subject}).should('exist')
     })
   })
 
@@ -180,6 +193,12 @@ describe('find* dom-testing-library commands', () => {
     })
 
     cy.findByText(/^Button Text/i, {timeout: 100})
+  })
+
+  it('findByText should not break existing code', () => {
+    cy.window()
+      .findByText('Button Text 1')
+      .should('exist')
   })
 })
 

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -200,6 +200,28 @@ describe('find* dom-testing-library commands', () => {
       .findByText('Button Text 1')
       .should('exist')
   })
+
+  it('findByText should show as a parent command if it starts a chain', () => {
+    const assertLog = (attrs, log) => {
+      if(log.get('name') === 'findByText') {
+        expect(log.get('type')).to.equal('parent')
+        cy.off('log:added', assertLog)
+      }
+    }
+    cy.on('log:added', assertLog)
+    cy.findByText('Button Text 1')
+  })
+
+  it('findByText should show as a child command if it continues a chain', () => {
+    const assertLog = (attrs, log) => {
+      if(log.get('name') === 'findByText') {
+        expect(log.get('type')).to.equal('child')
+        cy.off('log:added', assertLog)
+      }
+    }
+    cy.on('log:added', assertLog)
+    cy.get('body').findByText('Button Text 1')
+  })
 })
 
 /* global cy */

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 describe('find* dom-testing-library commands', () => {
   beforeEach(() => {
     cy.visit('cypress/fixtures/test-app/')
@@ -164,7 +162,7 @@ describe('find* dom-testing-library commands', () => {
       expect(err.message).to.contain(errorMessage)
     })
 
-    cy.findByText(regex, {timeout: 100}) // Every find query is implicitly a `.should('exist')
+    cy.findByText(regex, {timeout: 100})
   })
 
   it('findByText should default to Cypress non-existence error message', () => {
@@ -183,7 +181,7 @@ describe('find* dom-testing-library commands', () => {
       expect(err.message).to.contain(errorMessage)
     })
 
-    cy.findByLabelText('Label 3', {timeout: 100}).should('exist')
+    cy.findByLabelText('Label 3', {timeout: 100})
   })
 
   it('findByText finding multiple items should error', () => {

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines-per-function */
+
 describe('find* dom-testing-library commands', () => {
   beforeEach(() => {
     cy.visit('cypress/fixtures/test-app/')
@@ -86,6 +88,21 @@ describe('find* dom-testing-library commands', () => {
 
   /* Test the behaviour around these queries */
 
+  it('findByText should handle non-existence', () => {
+    cy.findByText('Does Not Exist')
+      .should('not.exist')
+  })
+
+  it('findByText should handle eventual existence', () => {
+    cy.findByText('Eventually Exists')
+      .should('exist')
+  })
+
+  it('findByText should handle eventual non-existence', () => {
+    cy.findByText('Eventually Not exists')
+      .should('not.exist')
+  })
+
   it("findByText with should('not.exist')", () => {
     cy.findAllByText(/^Button Text \d$/).should('exist')
     cy.findByText('Non-existing Button Text', {timeout: 100}).should(
@@ -123,23 +140,59 @@ describe('find* dom-testing-library commands', () => {
     cy.findByText('New Page Loaded').should('exist')
   })
 
-  it('findByText should error if no elements are found', () => {
-    const regex = /Supercalifragilistic/
-    const errorMessage = `Timed out retrying: Expected to find element: 'findByText(${regex})', but never found it.`
-    cy.on('fail', err => {
-      expect(err.message).to.eq(errorMessage)
+  it('findByText should set the Cypress element to the found element', () => {
+    // This test is a little strange since snapshots show what element
+    // is selected, but snapshots themselves don't give access to those
+    // elements. I had to make the implementation specific so that the `$el`
+    // is the `subject` when the log is added and the `$el` is the `value`
+    // when the log is changed. It would be better to extract the `$el` from
+    // each snapshot
+
+    cy.on('log:changed', (attrs, log) => {
+      if (log.get('name') === 'findByText') {
+        expect(log.get('$el')).to.have.text('Button Text 1')
+      }
     })
 
-    cy.findByText(regex, {timeout: 100}) // Doesn't explicitly need .should('exist') if it's the last element?
+    cy.findByText('Button Text 1')
+  })
+
+  it('findByText should error if no elements are found', () => {
+    const regex = /Supercalifragilistic/
+    const errorMessage = `Unable to find an element with the text: /Supercalifragilistic/`
+    cy.on('fail', err => {
+      expect(err.message).to.contain(errorMessage)
+    })
+
+    cy.findByText(regex, {timeout: 100}) // Every find query is implicitly a `.should('exist')
+  })
+
+  it('findByText should default to Cypress non-existence error message', () => {
+    const errorMessage = `Expected <button> not to exist in the DOM, but it was continuously found.`
+    cy.on('fail', err => {
+      expect(err.message).to.contain(errorMessage)
+    })
+
+    cy.findByText('Button Text 1', {timeout: 100})
+      .should('not.exist')
+  })
+
+  it('findByLabelText should forward useful error messages from @testing-library/dom', () => {
+    const errorMessage = `Found a label with the text of: Label 3, however no form control was found associated to that label.`
+    cy.on('fail', err => {
+      expect(err.message).to.contain(errorMessage)
+    })
+
+    cy.findByLabelText('Label 3', {timeout: 100}).should('exist')
   })
 
   it('findByText finding multiple items should error', () => {
     const errorMessage = `Found multiple elements with the text: /^Button Text/i\n\n(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).`
     cy.on('fail', err => {
-      expect(err.message).to.eq(errorMessage)
+      expect(err.message).to.contain(errorMessage)
     })
 
-    cy.findByText(/^Button Text/i)
+    cy.findByText(/^Button Text/i, {timeout: 100})
   })
 })
 

--- a/cypress/integration/query.spec.js
+++ b/cypress/integration/query.spec.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 describe('query* dom-testing-library commands', () => {
   beforeEach(() => {
     cy.visit('cypress/fixtures/test-app/')

--- a/cypress/integration/query.spec.js
+++ b/cypress/integration/query.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines-per-function */
+
 describe('query* dom-testing-library commands', () => {
   beforeEach(() => {
     cy.visit('cypress/fixtures/test-app/')
@@ -95,12 +97,30 @@ describe('query* dom-testing-library commands', () => {
     })
   })
 
+  it('queryByText should set the Cypress element to the found element', (done) => {
+    // This test is a little strange since snapshots show what element
+    // is selected, but snapshots themselves don't give access to those
+    // elements. I had to make the implementation specific so that the `$el`
+    // is the `subject` when the log is added and the `$el` is the `value`
+    // when the log is changed. It would be better to extract the `$el` from
+    // each snapshot
+
+    cy.on('log:changed', (attrs, log) => {
+      if (log.get('name') === 'queryByText') {
+        expect(log.get('$el')).to.have.text('Button Text 1')
+        done()
+      }
+    })
+
+    cy.queryByText('Button Text 1')
+  })
+
   it('query* will return immediately, and never retry', () => {
     cy.queryByText('Next Page').click()
 
-    const errorMessage = `expected 'queryByText(\`New Page Loaded\`)' to exist in the DOM`
+    const errorMessage = `Unable to find an element with the text: New Page Loaded.`
     cy.on('fail', err => {
-      expect(err.message).to.eq(errorMessage)
+      expect(err.message).to.contain(errorMessage)
     })
 
     cy.queryByText('New Page Loaded', { timeout: 300 }).should('exist')
@@ -129,23 +149,42 @@ describe('query* dom-testing-library commands', () => {
       .and('not.exist')
   })
 
-  it('queryAllByText with a should(\'exist\') must provide selector error message', () => {
+  it('queryAllByText should forward existence error message from @testing-library/dom', () => {
     const text = 'Supercalifragilistic'
-    const errorMessage = `expected 'queryAllByText(\`${text}\`)' to exist in the DOM`
+    const errorMessage = `Unable to find an element with the text: Supercalifragilistic.`
     cy.on('fail', err => {
-      expect(err.message).to.eq(errorMessage)
+      expect(err.message).to.contain(errorMessage)
     })
 
-    cy.queryAllByText(text, {timeout: 100}).should('exist') // NOT POSSIBLE WITH QUERYALL?
+    cy.queryAllByText(text, {timeout: 100}).should('exist')
+  })
+
+  it('queryByLabelText should forward useful error messages from @testing-library/dom', () => {
+    const errorMessage = `Found a label with the text of: Label 3, however no form control was found associated to that label.`
+    cy.on('fail', err => {
+      expect(err.message).to.contain(errorMessage)
+    })
+
+    cy.queryByLabelText('Label 3', {timeout: 100}).should('exist')
+  })
+
+  it('queryAllByText should default to Cypress non-existence error message', () => {
+    const errorMessage = `Expected <button> not to exist in the DOM, but it was continuously found.`
+    cy.on('fail', err => {
+      expect(err.message).to.contain(errorMessage)
+    })
+
+    cy.queryAllByText('Button Text 1', {timeout: 100})
+      .should('not.exist')
   })
 
   it('queryByText finding multiple items should error', () => {
-    const errorMessage = `Found multiple elements with the text: /^queryByText/i\n\n(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).`
+    const errorMessage = `Found multiple elements with the text: /^Button Text/i\n\n(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).`
     cy.on('fail', err => {
-      expect(err.message).to.eq(errorMessage)
+      expect(err.message).to.contain(errorMessage)
     })
 
-    cy.queryByText(/^queryByText/i)
+    cy.queryByText(/^Button Text/i)
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:cypress:run": "cypress run",
     "test:cypress:open": "cypress open",
     "test:cypress": "npm run test:cypress:run",
-    "test:cypress:dev": "test:cypress:open",
+    "test:cypress:dev": "npm run test:cypress:open",
     "validate": "kcd-scripts validate build,lint,test",
     "setup": "npm install && npm run validate -s"
   },

--- a/src/__tests__/add-commands.js
+++ b/src/__tests__/add-commands.js
@@ -11,6 +11,7 @@ test('adds commands to Cypress', () => {
   commands.forEach(({name}, index) => {
     expect(addMock.mock.calls[index]).toMatchObject([
       name,
+      {},
       // We get a new function that is `command.bind(null, cy)` i.e. global `cy` passed into the first argument.
       // The commands themselves will be tested separately in the Cypress end-to-end tests.
       expect.any(Function),

--- a/src/add-commands.js
+++ b/src/add-commands.js
@@ -1,7 +1,7 @@
 import {commands} from './'
 
-commands.forEach(({name, command}) => {
-  Cypress.Commands.add(name, command)
+commands.forEach(({name, command, options = {}}) => {
+  Cypress.Commands.add(name, options, command)
 })
 
 /* global Cypress */

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,7 @@ function createCommand(queryName, implementationName) {
 
       if (options.log) {
         options._log = Cypress.log({
+          type: prevSubject ? 'child' : 'parent',
           name: queryName,
           message: inputArr,
           consoleProps: () => consoleProps,

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,12 @@
-import {configure, queries} from '@testing-library/dom'
+import {configure as configureDTL, queries} from '@testing-library/dom'
 import {getContainer} from './utils'
 
 let globalFallbackRetryWithoutPreviousSubject = true
-const configureFn = configDelta => {
-  if (configDelta.fallbackRetryWithoutPreviousSubject != null) {
-    globalFallbackRetryWithoutPreviousSubject = configDelta.fallbackRetryWithoutPreviousSubject
-    delete configDelta.fallbackRetryWithoutPreviousSubject
+function configure({fallbackRetryWithoutPreviousSubject, ...config}) {
+  if (fallbackRetryWithoutPreviousSubject != null) {
+    globalFallbackRetryWithoutPreviousSubject = fallbackRetryWithoutPreviousSubject
   }
-  configure(configDelta)
+  return configureDTL(config)
 }
 
 const queryNames = Object.keys(queries)
@@ -213,7 +212,7 @@ function queryArgument(args) {
 
 const commands = [...getCommands, ...findCommands, ...queryCommands]
 
-export {commands, configureFn as configure}
+export {commands, configure}
 
 /* eslint no-new-func:0, complexity:0 */
 /* globals Cypress, cy */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Why are these changes necessary? -->

**Why**:

I'm a big fan of the React Testing Library and the concept behind it. I wanted those concepts to come to `@testing-library/cypress` as well, but the commands didn't do what I expected. It wasn't even until recently that #100 allowed a previous subject to be used! These commands are just too useful, but just lacked the last mile of finesse. Most of these issues are outlined in #103 

This PR closes some of the UX/DX gaps that built-in Cypress commands have.

My original intent was to break features up into separate PRs, but the features required changes to the same lines of code and could not be done independently. If it is a big concern, features can be introduced in separate PRs serially due to the interdependency of the same lines of code.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

* Add element selector information for debugging (outlines element when you click on command) (fixes #103)
Screenshot shows the element outline highlighted in the application view. Also showing which element is yielded, like other Cypress commands that return elements.
![Screen Shot 2020-01-30 at 11 04 52 AM](https://user-images.githubusercontent.com/338257/73476868-5f16dd00-4350-11ea-962f-fa4e65121580.png)

* Add @testing-library/dom errors (from `get*` queries) to failure messages - these are more helpful than the generic `find*('input') does not exist` messages (fixes #103)
![Screen Shot 2020-01-30 at 11 22 41 AM](https://user-images.githubusercontent.com/338257/73478188-dc435180-4352-11ea-822b-fa95cfac62f4.png)

* Add retryability to `findBy*` when multiple elements are found (fixes #83)
![Screen Shot 2020-01-30 at 11 23 28 AM](https://user-images.githubusercontent.com/338257/73478233-f5e49900-4352-11ea-9661-79930de55e16.png)

* Add option to disable logging of all commands
* `query*` and `find*` have a consistent code path and error messaging (fixes #103)
* Remove usage of Cypress commands in queries (fixes #103)
* Add ability to use a previous subject in a more idiomatic way without introducing breaking changes caused by #100 (fixes #109 and #110)
* Add parent/child log type detection for more accurate Cypress command logging ("Parent" aligns left while "child" is indented and preceded by a `-` like in the screenshot)
<img width="574" alt="Screen Shot 2020-01-30 at 10 33 01 PM" src="https://user-images.githubusercontent.com/338257/73515254-e34d7c80-43b1-11ea-9b0f-6cfcaecad8ef.png">


**How**:

I tried to make test cases for all changes. They should all fail without these changes. I'm happy to add more if I've missed any. I've tested changes against a local branch of https://github.com/Workday/canvas-kit using `@testing-library/cypress` and things are working.

**Breaking Changes?**:

`query*` will now fail if no element was found. Before the command would pass an empty object which could cause the next command to fail (e.g. `.click()`). If a `query*` failed to return an element, a `.should('exist')` would not fail because the assertion was given a non-null value. With this change the test should pass/fail as expected, but not as previously implemented.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I don't expect this PR to be merged right away and I expect some conversation.

Some open questions:
- [x] Should `get*` queries be allowed instead of throwing errors? This library is now using `@testing-library/dom` `get*` APIs for error messages. If that's the case, `get*`, `query*`, and `find*` all would use the same underlying implementation.
- [x] Does the difference between `*By*` and `*AllBy*` make sense in the context of Cypress? Cypress DOM APIs return a jQuery NodeList with one or more elements. Most of the time this is completely fine and expected, but certain commands expect only one element. For example, `.click` will throw an error if handed multiple elements. `.first()` can easily be used to return only the first one or the previous query can be updated to return only one. If a user expects a certain number (including only one), the command can be followed by `.should('have.length', 1)` if the test is meant to ensure only a single element exists in the DOM and fail otherwise - so single vs multiple is opt-in for other elements.