### PR TITLE
Fix chain commands with previous subject different of document, element or window

### DIFF
--- a/cypress/fixtures/test-app/index.html
+++ b/cypress/fixtures/test-app/index.html
@@ -15,6 +15,13 @@
     section {
       padding: 10px;
     }
+    input:valid + span {
+      display: none;
+    }
+    input:invalid + span {
+      display: block;
+      color: red;
+    }
   </style>
 </head>
 <body>
@@ -109,6 +116,13 @@
         document.querySelector('#eventually-will-not-exist').remove()
       }, 500)
     </script>
+  </section>
+  <section>
+    <h2>Chain selectors</h2>
+    <form onsubmit="return false" action="#">
+      <label>Required: <input type="text" required /><span>Error message</span></label>
+      <button type="submit">Submit</button>
+    </form>
   </section>
 <!-- Prettier unindents the script tag below -->
 <script>

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -88,18 +88,15 @@ describe('find* dom-testing-library commands', () => {
   /* Test the behaviour around these queries */
 
   it('findByText should handle non-existence', () => {
-    cy.findByText('Does Not Exist')
-      .should('not.exist')
+    cy.findByText('Does Not Exist').should('not.exist')
   })
 
   it('findByText should handle eventual existence', () => {
-    cy.findByText('Eventually Exists')
-      .should('exist')
+    cy.findByText('Eventually Exists').should('exist')
   })
 
   it('findByText should handle eventual non-existence', () => {
-    cy.findByText('Eventually Not exists')
-      .should('not.exist')
+    cy.findByText('Eventually Not exists').should('not.exist')
   })
 
   it("findByText with should('not.exist')", () => {
@@ -111,7 +108,7 @@ describe('find* dom-testing-library commands', () => {
 
   it('findByText with a previous subject', () => {
     cy.get('#nested')
-      .findByText('Button Text 1', { fallbackRetryWithoutPreviousSubject: false })
+      .findByText('Button Text 1', {fallbackRetryWithoutPreviousSubject: false})
       .should('not.exist')
     cy.get('#nested')
       .findByText('Button Text 2')
@@ -170,8 +167,7 @@ describe('find* dom-testing-library commands', () => {
       expect(err.message).to.contain(errorMessage)
     })
 
-    cy.findByText('Button Text 1', {timeout: 100})
-      .should('not.exist')
+    cy.findByText('Button Text 1', {timeout: 100}).should('not.exist')
   })
 
   it('findByLabelText should forward useful error messages from @testing-library/dom', () => {
@@ -196,11 +192,14 @@ describe('find* dom-testing-library commands', () => {
     cy.window()
       .findByText('Button Text 1')
       .should('exist')
+    cy.location()
+      .findByText('Button Text 1')
+      .should('exist')
   })
 
   it('findByText should show as a parent command if it starts a chain', () => {
     const assertLog = (attrs, log) => {
-      if(log.get('name') === 'findByText') {
+      if (log.get('name') === 'findByText') {
         expect(log.get('type')).to.equal('parent')
         cy.off('log:added', assertLog)
       }
@@ -211,13 +210,24 @@ describe('find* dom-testing-library commands', () => {
 
   it('findByText should show as a child command if it continues a chain', () => {
     const assertLog = (attrs, log) => {
-      if(log.get('name') === 'findByText') {
+      if (log.get('name') === 'findByText') {
         expect(log.get('type')).to.equal('child')
         cy.off('log:added', assertLog)
       }
     }
     cy.on('log:added', assertLog)
     cy.get('body').findByText('Button Text 1')
+  })
+
+  it('should chain findBy* with subject different of document, element or window', () => {
+    cy.wrap(true)
+      .should('be.true')
+      .findByText('Error message')
+      .findByLabelText(/Required/i)
+      .type('something')
+      .findByText('Submit')
+      .queryByText('Error message')
+      .should('not.be.visible')
   })
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const findCommands = findQueryNames.map(queryName => {
 function createCommand(queryName, implementationName) {
   return {
     name: queryName,
-    options: {prevSubject: ['optional', 'document', 'element', 'window']},
+    options: {prevSubject: ['optional']},
     command: (prevSubject, ...args) => {
       const lastArg = args[args.length - 1]
       const defaults = {


### PR DESCRIPTION
**What**:

Allow commands to be chained when previous command does not returns document, element or window

**Why**:

Fix #114 

**How**:

Remove document, element or window from `prevSubject` in `createCommand`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
