### PR TITLE
chore: add deprecation warning to query*

### DIFF
--- a/cypress/integration/query.spec.js
+++ b/cypress/integration/query.spec.js
@@ -85,16 +85,18 @@ describe('query* dom-testing-library commands', () => {
 
   /* Test the behaviour around these queries */
 
-  it('should handle previous ways of querying non-existence', () => {
-    cy.queryByText('Eventually not exists').then($el => {
-      cy.wrap($el).should('not.exist')
+  it('queryByText should show a deprecation warning', () => {
+    let addedLog
+    cy.on('log:added', (_, log) => {
+      addedLog = log
     })
-  })
-
-  it('should handle previous ways of querying eventual non-existence', () => {
-    cy.queryByText(`Currently does not exist`).then($el => {
-      cy.wrap($el).should('not.exist')
-    })
+    cy.queryByText('Button Text 1')
+      .then(() => {
+        const attrs = addedLog.toJSON()
+        expect(attrs).to.have.property('state', 'failed')
+        expect(attrs).to.have.deep.property('err.message')
+        expect(attrs.err.message).to.contain(`@testing-library/cypress is deprecating all 'query*' commands.`)
+      })
   })
 
   it('queryByText with .should(\'not.exist\')', () => {
@@ -129,7 +131,7 @@ describe('query* dom-testing-library commands', () => {
   it('query* will return immediately, and never retry', () => {
     cy.queryByText('Next Page').click()
 
-    const errorMessage = "'queryByText(`New Page Loaded`)' to exist in the DOM"
+    const errorMessage = `Unable to find an element with the text: New Page Loaded.`
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })
@@ -162,7 +164,7 @@ describe('query* dom-testing-library commands', () => {
 
   it('queryAllByText should forward existence error message from @testing-library/dom', () => {
     const text = 'Supercalifragilistic'
-    const errorMessage = "'queryAllByText(`Supercalifragilistic`)' to exist in the DOM"
+    const errorMessage = `Unable to find an element with the text: Supercalifragilistic.`
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })
@@ -171,7 +173,7 @@ describe('query* dom-testing-library commands', () => {
   })
 
   it('queryByLabelText should forward useful error messages from @testing-library/dom', () => {
-    const errorMessage = "'queryByLabelText(`Label 3`)' to exist in the DOM"
+    const errorMessage = `Found a label with the text of: Label 3, however no form control was found associated to that label.`
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })
@@ -180,7 +182,7 @@ describe('query* dom-testing-library commands', () => {
   })
 
   it('queryAllByText should default to Cypress non-existence error message', () => {
-    const errorMessage = `expected '<button>' not to exist in the DOM`
+    const errorMessage = `Expected <button> not to exist in the DOM, but it was continuously found.`
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })

--- a/cypress/integration/query.spec.js
+++ b/cypress/integration/query.spec.js
@@ -99,7 +99,7 @@ describe('query* dom-testing-library commands', () => {
       cy.wrap(null).should(() => {
         const attrs = addedLog.toJSON()
         expect(attrs).to.have.property('state', 'failed')
-        expect(attrs).to.have.deep.property('err.message')
+        expect(attrs).to.have.nested.property('err.message')
         expect(attrs.err.message).to.contain(`@testing-library/cypress is deprecating all 'query*' commands.`)
       })
   })

--- a/cypress/integration/query.spec.js
+++ b/cypress/integration/query.spec.js
@@ -85,6 +85,18 @@ describe('query* dom-testing-library commands', () => {
 
   /* Test the behaviour around these queries */
 
+  it('should handle previous ways of querying non-existence', () => {
+    cy.queryByText('Eventually not exists').then($el => {
+      cy.wrap($el).should('not.exist')
+    })
+  })
+
+  it('should handle previous ways of querying eventual non-existence', () => {
+    cy.queryByText(`Currently does not exist`).then($el => {
+      cy.wrap($el).should('not.exist')
+    })
+  })
+
   it('queryByText with .should(\'not.exist\')', () => {
     cy.queryAllByText(/^Button Text \d$/).should('exist')
     cy.queryByText('Non-existing Button Text', {timeout: 100}).should('not.exist')
@@ -117,7 +129,7 @@ describe('query* dom-testing-library commands', () => {
   it('query* will return immediately, and never retry', () => {
     cy.queryByText('Next Page').click()
 
-    const errorMessage = `Unable to find an element with the text: New Page Loaded.`
+    const errorMessage = "'queryByText(`New Page Loaded`)' to exist in the DOM"
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })
@@ -150,7 +162,7 @@ describe('query* dom-testing-library commands', () => {
 
   it('queryAllByText should forward existence error message from @testing-library/dom', () => {
     const text = 'Supercalifragilistic'
-    const errorMessage = `Unable to find an element with the text: Supercalifragilistic.`
+    const errorMessage = "'queryAllByText(`Supercalifragilistic`)' to exist in the DOM"
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })
@@ -159,7 +171,7 @@ describe('query* dom-testing-library commands', () => {
   })
 
   it('queryByLabelText should forward useful error messages from @testing-library/dom', () => {
-    const errorMessage = `Found a label with the text of: Label 3, however no form control was found associated to that label.`
+    const errorMessage = "'queryByLabelText(`Label 3`)' to exist in the DOM"
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })
@@ -168,7 +180,7 @@ describe('query* dom-testing-library commands', () => {
   })
 
   it('queryAllByText should default to Cypress non-existence error message', () => {
-    const errorMessage = `Expected <button> not to exist in the DOM, but it was continuously found.`
+    const errorMessage = `expected '<button>' not to exist in the DOM`
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const getCommands = getQueryNames.map(queryName => {
 })
 
 const queryCommands = queryQueryNames.map(queryName => {
-  return createCommand(queryName, queryName.replace(queryRegex, 'get'))
+  return createCommand(queryName, queryName)
 })
 
 const findCommands = findQueryNames.map(queryName => {
@@ -160,6 +160,13 @@ function createCommand(queryName, implementationName) {
               }
             })
         })
+      }
+
+      if (queryRegex.test(queryName)) {
+        const value = getValue()
+        options._log.snapshot().error(Error(`@testing-library/cypress is deprecating all 'query*' commands. 'find*' queries support non-existence starting with version 5 (E.g. cy.findByText('Does Not Exist').should('not.exist')). Please use cy.${queryName.replace(queryRegex, 'find')}(${queryArgument(args)}) instead.`))
+
+        return value
       }
 
       return resolveValue().then(subject => {

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const getCommands = getQueryNames.map(queryName => {
 })
 
 const queryCommands = queryQueryNames.map(queryName => {
-  return createCommand(queryName, queryName)
+  return createCommand(queryName, queryName.replace(queryRegex, 'get'))
 })
 
 const findCommands = findQueryNames.map(queryName => {
@@ -162,13 +162,6 @@ function createCommand(queryName, implementationName) {
         })
       }
 
-      if (queryRegex.test(queryName)) {
-        const value = getValue()
-        options._log.snapshot().error(Error(`@testing-library/cypress is deprecating all 'query*' commands. 'find*' queries support non-existence starting with version 5 (E.g. cy.findByText('Does Not Exist').should('not.exist')). Please use cy.${queryName.replace(queryRegex, 'find')}(${queryArgument(args)}) instead.`))
-
-        return value
-      }
-
       return resolveValue().then(subject => {
         // Remove the error that occurred because it is irrelevant now
         if (consoleProps.error) {
@@ -181,7 +174,9 @@ function createCommand(queryName, implementationName) {
         return subject
       }).finally(() => {
         if (options._log) {
-          if (failedNewFunctionality && !failedOldFunctionality) {
+          if (queryRegex.test(queryName)) {
+            options._log.error(Error(`@testing-library/cypress is deprecating all 'query*' commands. 'find*' queries support non-existence starting with version 5 (E.g. cy.findByText('Does Not Exist').should('not.exist')). Please use cy.${queryName.replace(queryRegex, 'find')}(${queryArgument(args)}) instead.`))
+          } else if (failedNewFunctionality && !failedOldFunctionality) {
             options._log.error(Error(`@testing-library/cypress will eventually only use previous subjects when queries are added to a chain of commands. We've detected an instance where the this functionality failed, but the old functionality passed (so your test may break in a future version). Please use cy.${queryName}(${queryArgument(args)}) instead of continuing from a previous chain.`))
           } else {
             options._log.end()


### PR DESCRIPTION
Fixes #117

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

This PR is overdue. I had the fix for a while, but sat on it too long. If you read up on #117, you'll see the person who filed the bug no longer has the issue. This PR does revert the `query*` functionality to what it was previously. The functionality difference is subtle, but I'll explain it here:

After #108, `query*` was subtly changed to have the same functionality as `find*` queries, but with no retries. This changed the error messages (they were more helpful), but also changed the way the command worked which would break in this circumstance:

```js
cy.queryByText('Never Exists').then(val => {
  cy.wrap(val).should('not.exist')
})
```

Before the `cy.queryByText('Never Exists')` would return `null` and the test would pass. After, the `cy.queryByText('Never Exists')` ran through Cypress's internal verification of upcoming assertions. Implicitly a `.should('exist')` was added to all commands that didn't explicitly have an assertion, making the command run like the following:

```js
cy.queryByText('Never Exists').should('exist').then(val => {
  cy.wrap(val).should('not.exist')
})
```

With this subtle change, immediate non-existence no longer works with `query*` because it is first expected to exist and will fail before the `.then` is called.

There is a deprecation warning that states `query*` should not be used and to use `find*` instead. The next major release will remove `query*`. Within the context of Cypress, only the `find*` line of queries make sense. All Cypress commands retry since all Cypress commands are asynchronous and `query*` was only useful because `find*` didn't handle eventual non-existence well.
