### PR TITLE
fix: Fix ESLint config and failing test

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "./node_modules/kcd-scripts/eslint.js",
+  "rules": {
+    "max-lines-per-function": "off",
+    "testing-library/no-dom-import": "off" // We're not using React Testing Library here. We're wrapping DOM Testing Library directly
+  }
+}

--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -1,6 +1,11 @@
 {
   "rules": {
-    "max-lines-per-function": "off",
-    "jest/valid-expect-in-promise": "off"
+    "testing-library/await-async-query": "off", // Cypress chains don't use promises
+    "testing-library/prefer-screen-queries": "off", // screen queries don't make sense in the context of Cypress Testing Library
+
+    // No Jest here
+    "jest/valid-expect": "off",
+    "jest/valid-expect-in-promise": "off",
+    "jest/no-conditional-expect": "off"
   }
 }

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -7,9 +7,7 @@ describe('find* dom-testing-library commands', () => {
   // Test each of the types of queries: LabelText, PlaceholderText, Text, DisplayValue, AltText, Title, Role, TestId
 
   it('findByLabelText', () => {
-    cy.findByLabelText('Label 1')
-      .click()
-      .type('Hello Input Labelled By Id')
+    cy.findByLabelText('Label 1').click().type('Hello Input Labelled By Id')
   })
 
   it('findAllByLabelText', () => {
@@ -17,9 +15,7 @@ describe('find* dom-testing-library commands', () => {
   })
 
   it('findByPlaceholderText', () => {
-    cy.findByPlaceholderText('Input 1')
-      .click()
-      .type('Hello Placeholder')
+    cy.findByPlaceholderText('Input 1').click().type('Hello Placeholder')
   })
 
   it('findAllByPlaceholderText', () => {
@@ -27,9 +23,7 @@ describe('find* dom-testing-library commands', () => {
   })
 
   it('findByText', () => {
-    cy.findByText('Button Text 1')
-      .click()
-      .should('contain', 'Button Clicked')
+    cy.findByText('Button Text 1').click().should('contain', 'Button Clicked')
   })
 
   it('findAllByText', () => {
@@ -107,12 +101,8 @@ describe('find* dom-testing-library commands', () => {
   })
 
   it('findByText with a previous subject', () => {
-    cy.get('#nested')
-      .findByText('Button Text 1')
-      .should('not.exist')
-    cy.get('#nested')
-      .findByText('Button Text 2')
-      .should('exist')
+    cy.get('#nested').findByText('Button Text 1').should('not.exist')
+    cy.get('#nested').findByText('Button Text 2').should('exist')
   })
 
   it('findByText within', () => {
@@ -180,7 +170,7 @@ describe('find* dom-testing-library commands', () => {
   })
 
   it('findByText finding multiple items should error', () => {
-    const errorMessage = `Found multiple elements with the text: /^Button Text/i\n\n(If this is intentional, then use the \`*AllBy*\` variant of the query (like \`queryAllByText\`, \`getAllByText\`, or \`findAllByText\`)).`
+    const errorMessage = `Found multiple elements with the text: /^Button Text/i`
     cy.on('fail', err => {
       expect(err.message).to.contain(errorMessage)
     })


### PR DESCRIPTION

* DOM Testing Library changed an error message when multiple DOM nodes are found, so the test was updated to look for a smaller subset of the error. We don't have control over the error message, but want to make sure the right one was thrown.

* Testing Library added more linting rules that don't make sense in the context of Cypress Testing Library, so these lint rules have been disabled to not confuse contributors.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
