### PR TITLE
Move types from DefinitelyTyped

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,13 @@ This allows you to use all the useful
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Installation](#installation)
   - [With TypeScript](#with-typescript)
+  - [Intellisense for JavaScript with VS Code](#intellisense-for-javascript-with-vs-code)
 - [Usage](#usage)
   - [Differences from DOM Testing Library](#differences-from-dom-testing-library)
+- [Config testIdAttribute](#config-testidattribute)
 - [Other Solutions](#other-solutions)
 - [Contributors](#contributors)
 - [LICENSE](#license)
@@ -79,21 +82,21 @@ npm install --save-dev @testing-library/cypress
 
 ### With TypeScript
 
-Typings are defined in `@types/testing-library__cypress` at
-[DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__cypress),
-and should be added as follows in `tsconfig.json`:
+Typings should be added as follows in `tsconfig.json`:
 
 ```json
 {
   "compilerOptions": {
-    "types": ["cypress", "@types/testing-library__cypress"]
+    "types": ["cypress", "@testing-library/cypress"]
   }
 }
 ```
 
 ### Intellisense for JavaScript with VS Code
 
-If you're not using TypeScript, you use VS Code, and want to have code-completion with the methods from this library, simply add the following line to your project's root-level `jsconfig.json` file:
+If you're not using TypeScript, you use VS Code, and want to have
+code-completion with the methods from this library, simply add the following
+line to your project's root-level `jsconfig.json` file:
 
 ```json
 {
@@ -116,7 +119,7 @@ commands.
 [See the `DOM Testing Library` docs for reference](https://testing-library.com)
 
 You can find
-[all Library definitions here](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__cypress/index.d.ts).
+[all Library definitions here](https://github.com/testing-library/cypress-testing-library/tree/master/types/index.d.ts).
 
 To configure DOM Testing Library, use the following custom command:
 
@@ -134,9 +137,7 @@ cy.findAllByLabelText('Label text', {timeout: 7000}).should('exist')
 cy.findAllByText('Jackie Chan').click()
 
 // findAllByText _inside_ a form element
-cy.get('form')
-  .findAllByText('Button Text')
-  .should('exist')
+cy.get('form').findAllByText('Button Text').should('exist')
 ```
 
 ### Differences from DOM Testing Library
@@ -177,14 +178,16 @@ cy.findByText('Some Text').should('exist')
 
 ## Config testIdAttribute
 
-If you would like to change the default testId from `data-testId` to `data-test-id`, add to your project's `cypress/support/index.js`:
+If you would like to change the default testId from `data-testId` to
+`data-test-id`, add to your project's `cypress/support/index.js`:
 
 ```javascript
 import {configure} from '@testing-library/cypress'
 configure({testIdAttribute: 'data-test-id'})
 ```
 
-It accepts all configurations listed in [DOM testing library](https://testing-library.com/docs/dom-testing-library/api-configuration).
+It accepts all configurations listed in
+[DOM testing library](https://testing-library.com/docs/dom-testing-library/api-configuration).
 
 ## Other Solutions
 
@@ -247,6 +250,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.
@@ -297,5 +301,6 @@ MIT
 [all-contributors]: https://github.com/all-contributors/all-contributors
 [dom-testing-library]: https://github.com/testing-library/dom-testing-library
 [cypress]: https://www.cypress.io/
-[discord-badge]: https://img.shields.io/discord/723559267868737556.svg?color=7389D8&labelColor=6A7EC2&logo=discord&logoColor=ffffff&style=flat-square
+[discord-badge]:
+  https://img.shields.io/discord/723559267868737556.svg?color=7389D8&labelColor=6A7EC2&logo=discord&logoColor=ffffff&style=flat-square
 [discord]: https://discord.gg/c6JN9fM

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-semantically-released",
   "description": "Simple and complete custom Cypress commands and utilities that encourage good testing practices.",
   "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">=10",
     "npm": ">=6"
@@ -18,11 +19,13 @@
     "test:cypress:run": "cypress run",
     "test:unit": "kcd-scripts test --no-watch",
     "test:unit:watch": "kcd-scripts test",
+    "typecheck": "dtslint ./types/",
     "validate": "kcd-scripts validate build,lint,test"
   },
   "files": [
     "dist",
-    "add-commands.js"
+    "add-commands.js",
+    "types"
   ],
   "keywords": [
     "testing",
@@ -38,11 +41,11 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@testing-library/dom": "^7.1.0",
-    "@types/testing-library__cypress": "^5.0.3"
+    "@testing-library/dom": "^7.1.0"
   },
   "devDependencies": {
     "cypress": "^4.2.0",
+    "dtslint": "^3.6.14",
     "kcd-scripts": "^5.5.0",
     "npm-run-all": "^4.1.5"
   },

--- a/types/add-commands.d.ts
+++ b/types/add-commands.d.ts
@@ -1,0 +1,2 @@
+// Allow `import '@testing-library/cypress/add-commands'` from a `cypress/commands.ts` file
+import './';

--- a/types/add-commands.d.ts
+++ b/types/add-commands.d.ts
@@ -1,2 +1,2 @@
 // Allow `import '@testing-library/cypress/add-commands'` from a `cypress/commands.ts` file
-import './';
+import './'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,442 @@
+// TypeScript Version: 3.8
+
+import {
+  configure,
+  Matcher,
+  MatcherOptions as DTLMatcherOptions,
+  ByRoleOptions as DTLByRoleOptions,
+  SelectorMatcherOptions as DTLSelectorMatcherOptions,
+} from '@testing-library/dom';
+
+export interface CTLMatcherOptions {
+  timeout?: number;
+  container?: HTMLElement | JQuery;
+}
+
+export type MatcherOptions = DTLMatcherOptions | CTLMatcherOptions;
+export type ByRoleOptions = DTLByRoleOptions | CTLMatcherOptions;
+export type SelectorMatcherOptions = DTLSelectorMatcherOptions | CTLMatcherOptions;
+
+declare global {
+  namespace Cypress {
+      interface Chainable<Subject = any> {
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryAllByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findAllByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryAllByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findAllByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryAllByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findAllByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryAllByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findAllByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryAllByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findAllByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryAllByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findAllByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryAllByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findAllByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          queryAllByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>;
+
+          /**
+           * dom-testing-library helpers for Cypress
+           *
+           * `findBy*` APIs search for an element and throw an error if nothing found
+           * `findAllBy*` APIs search for all elements and an error if nothing found
+           * `queryBy*` APIs search for an element and returns null if nothing found
+           * `queryAllBy*` APIs search for all elements and return empty array if nothing found
+           *
+           * @see https://github.com/testing-library/cypress-testing-library#usage
+           * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+           */
+          findAllByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>;
+      }
+  }
+}
+
+export { configure };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,16 +6,16 @@ import {
   MatcherOptions as DTLMatcherOptions,
   ByRoleOptions as DTLByRoleOptions,
   SelectorMatcherOptions as DTLSelectorMatcherOptions,
-} from '@testing-library/dom';
+} from '@testing-library/dom'
 
 export interface CTLMatcherOptions {
-  timeout?: number;
-  container?: HTMLElement | JQuery;
+  timeout?: number
+  container?: HTMLElement | JQuery
 }
 
-export type MatcherOptions = DTLMatcherOptions | CTLMatcherOptions;
-export type ByRoleOptions = DTLByRoleOptions | CTLMatcherOptions;
-export type SelectorMatcherOptions = DTLSelectorMatcherOptions | CTLMatcherOptions;
+export type MatcherOptions = DTLMatcherOptions | CTLMatcherOptions
+export type ByRoleOptions = DTLByRoleOptions | CTLMatcherOptions
+export type SelectorMatcherOptions = DTLSelectorMatcherOptions | CTLMatcherOptions
 
 declare global {
   namespace Cypress {
@@ -31,7 +31,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -44,7 +44,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryAllByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryAllByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -57,7 +57,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -70,7 +70,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findAllByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findAllByPlaceholderText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -83,7 +83,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+          queryByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -96,7 +96,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryAllByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+          queryAllByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -109,7 +109,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+          findByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -122,7 +122,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findAllByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+          findAllByText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -135,7 +135,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+          queryByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -148,7 +148,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryAllByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+          queryAllByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -161,7 +161,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+          findByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -174,7 +174,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findAllByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>;
+          findAllByLabelText(id: Matcher, options?: SelectorMatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -187,7 +187,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -200,7 +200,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryAllByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryAllByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -213,7 +213,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -226,7 +226,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findAllByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findAllByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -239,7 +239,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -252,7 +252,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryAllByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryAllByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -265,7 +265,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -278,7 +278,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findAllByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findAllByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -291,7 +291,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -304,7 +304,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryAllByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryAllByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -317,7 +317,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -330,7 +330,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findAllByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findAllByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -343,7 +343,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -356,7 +356,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryAllByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          queryAllByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -369,7 +369,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -382,7 +382,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findAllByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>;
+          findAllByDisplayValue(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -395,7 +395,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>;
+          queryByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -408,7 +408,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          queryAllByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>;
+          queryAllByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -421,7 +421,7 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>;
+          findByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>
 
           /**
            * dom-testing-library helpers for Cypress
@@ -434,9 +434,9 @@ declare global {
            * @see https://github.com/testing-library/cypress-testing-library#usage
            * @see https://github.com/testing-library/dom-testing-library#table-of-contents
            */
-          findAllByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>;
+          findAllByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>
       }
   }
 }
 
-export { configure };
+export { configure }

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,0 +1,52 @@
+/// <reference types="Cypress" />
+import { configure } from '@testing-library/cypress';
+import '@testing-library/cypress/add-commands';
+
+configure({ testIdAttribute: 'data-myown-testid' });
+
+// findBy*
+cy.findByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+
+// findAllBy*
+cy.findAllByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+
+// queryBy*
+cy.queryByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+
+// queryAllBy*
+cy.queryAllByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+
+// with container option
+const container = document.createElement('div');
+cy.queryAllByRole('foo', { container }); // $ExpectType Chainable<JQuery<HTMLElement>>
+
+const $container = cy.$$('body').append('div');
+cy.queryAllByRole('foo', { container: $container }); // $ExpectType Chainable<JQuery<HTMLElement>>

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,52 +1,52 @@
 /// <reference types="Cypress" />
-import { configure } from '@testing-library/cypress';
-import '@testing-library/cypress/add-commands';
+import { configure } from '@testing-library/cypress'
+import '@testing-library/cypress/add-commands'
 
-configure({ testIdAttribute: 'data-myown-testid' });
+configure({ testIdAttribute: 'data-myown-testid' })
 
 // findBy*
-cy.findByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByPlaceholderText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByLabelText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByAltText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByTestId('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByTitle('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByDisplayValue('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findByRole('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 
 // findAllBy*
-cy.findAllByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findAllByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findAllByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findAllByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findAllByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findAllByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findAllByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.findAllByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByPlaceholderText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByLabelText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByAltText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByTestId('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByTitle('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByDisplayValue('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.findAllByRole('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 
 // queryBy*
-cy.queryByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByPlaceholderText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByLabelText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByAltText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByTestId('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByTitle('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByDisplayValue('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryByRole('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 
 // queryAllBy*
-cy.queryAllByPlaceholderText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryAllByText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryAllByLabelText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryAllByAltText('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryAllByTestId('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryAllByTitle('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryAllByDisplayValue('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
-cy.queryAllByRole('foo'); // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByPlaceholderText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByLabelText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByAltText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByTestId('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByTitle('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByDisplayValue('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+cy.queryAllByRole('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 
 // with container option
-const container = document.createElement('div');
-cy.queryAllByRole('foo', { container }); // $ExpectType Chainable<JQuery<HTMLElement>>
+const container = document.createElement('div')
+cy.queryAllByRole('foo', { container }) // $ExpectType Chainable<JQuery<HTMLElement>>
 
-const $container = cy.$$('body').append('div');
-cy.queryAllByRole('foo', { container: $container }); // $ExpectType Chainable<JQuery<HTMLElement>>
+const $container = cy.$$('body').append('div')
+cy.queryAllByRole('foo', { container: $container }) // $ExpectType Chainable<JQuery<HTMLElement>>

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "noEmit": true,
+    "types": [],
+    "paths": {
+      "@testing-library/cypress": ["."]
+    }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["dtslint/dtslint.json"],
+  "rules": {
+    "no-useless-files": false,
+    "no-relative-import-in-test": false,
+    "semicolon": false,
+    "whitespace": false
+  }
+}


### PR DESCRIPTION
**What**:

Move types from DefinitelyTyped to this repository.

**Why**:

Reduce the amount of additional dependencies required and avoid issues [like the one described here.](https://github.com/testing-library/cypress-testing-library/issues/121)

**How**:

Followed the approach taken in https://github.com/testing-library/react-testing-library/pull/690 and https://github.com/testing-library/dom-testing-library/pull/530

**Checklist**:

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged

---

The pre-commit hook was complaining about some type definition conflicts (as mentioned [here](https://github.com/testing-library/cypress-testing-library/issues/145#issuecomment-673327836)) when running `tsc` so I had to skip it to create the PR. I could use some help resolving that if anyone becomes available. 
