### PR TITLE
fix: allow cypress@6 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^4.0.5"
   },
   "peerDependencies": {
-    "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+    "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Update for new release: https://docs.cypress.io/guides/references/changelog.html#6-0-0

<!-- Why are these changes necessary? -->

**Why**:

To avoid peer dep warnings when installing

<!-- How were these changes implemented? -->

**How**:

GH editor. I also tested with cypress v6 at work

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
