### PR TITLE
Fix findByRole() and findAllByRole() type definition to check role name

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,7 @@
 import {
   configure,
   Matcher,
+  ByRoleMatcher,
   MatcherOptions as DTLMatcherOptions,
   ByRoleOptions as DTLByRoleOptions,
   SelectorMatcherOptions as DTLSelectorMatcherOptions,
@@ -211,7 +212,7 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>
+      findByRole(id: ByRoleMatcher, options?: ByRoleOptions): Chainable<JQuery>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -222,7 +223,7 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findAllByRole(id: Matcher, options?: ByRoleOptions): Chainable<JQuery>
+      findAllByRole(id: ByRoleMatcher, options?: ByRoleOptions): Chainable<JQuery>
 
       /**
        * dom-testing-library helpers for Cypress


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix  findByRole() and findAllByRole() type definition to check role name as same as upstream @testing-library/dom does.

<!-- Why are these changes necessary? -->

**Why**:

Current type definition uses Matcher type this is for jQuery selector.

<!-- How were these changes implemented? -->

**How**:

Switch role name type to ByRoleMatcher that is used in @testing-library/dom.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation: N/A
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I confirmed VSCode shows role names in completion word list.

<img width="670" alt="スクリーンショット 2021-02-20 22 09 22" src="https://user-images.githubusercontent.com/564612/108611604-64dfd480-7423-11eb-859f-5164b69f54cb.png">


<!-- feel free to add additional comments -->
