### PR TITLE
Update @testing-library/dom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^7.28.1"
+    "@testing-library/dom": "^7.29.6"
   },
   "devDependencies": {
     "cypress": "^6.0.1",


### PR DESCRIPTION
**What**:

Bumps the `@testing-library/dom` version to `^7.29.6`

**Why**:

Currently when using the `expanded` option in `cy.findByRole` Typescript complains that `expanded` is not defined in the `ByRoleOptions` type. 

Example:

```javascript
cy.findByRole("button", {
  name: /button-label/i,
  expanded: true, // the expanded prop is not allowed by typescript
})
```


This is because the `@testing-library/dom v7.28.1` that's being referenced in `package.json` doesn't have the `expanded` property defined in `queries.d.ts`

**How**:

I've updated the `@testing-library/dom` version in `package.json`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests
- [ ] Ready to be merged

The version of `@testing-library/dom` went from `7.28.1` -> `7.29.6`, the most significant change between those versions was adding types I think.

I'd like to try it out in one of my own projects that use `cypress-testing-library` first, but I'm not really sure how to build this package locally. Some help on that would be appreciated. Or if you don't expect any issues from this, then of course it can be merged.

