### PR TITLE
fix(types): exclude tsconfig from types folder in publish flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "files": [
     "dist",
     "add-commands.js",
-    "types"
+    "types/*.d.ts"
   ],
   "keywords": [
     "testing",


### PR DESCRIPTION
Port of https://github.com/testing-library/react-testing-library/pull/893
