### PR TITLE
chore: rename proj. from master to main

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - '+([0-9])?(.{+([0-9]),x}).x'
-      - 'master'
+      - 'main'
       - 'next'
       - 'next-major'
       - 'beta'
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     if:
       ${{ github.repository == 'testing-library/cypress-testing-library' &&
-      contains('refs/heads/master,refs/heads/beta,refs/heads/next,refs/heads/alpha',
+      contains('refs/heads/main,refs/heads/beta,refs/heads/next,refs/heads/alpha',
       github.ref) && github.event_name == 'push' }}
     steps:
       - name: 🛑 Cancel Previous Runs
@@ -79,7 +79,7 @@ jobs:
           branches: |
             [
               '+([0-9])?(.{+([0-9]),x}).x',
-              'master',
+              'main',
               'next',
               'next-major',
               {name: 'beta', prerelease: true},

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,20 +11,20 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 2.  Run `npm run setup -s` to install dependencies and run validation
 3.  Create a branch for your PR with `git checkout -b pr/your-branch-name`
 
-> Tip: Keep your `master` branch pointing at the original repository and make
+> Tip: Keep your `main` branch pointing at the original repository and make
 > pull requests from branches on your fork. To do this, run:
 >
 > ```
 > git remote add upstream https://github.com/kentcdodds/cypress-testing-library.git
 > git fetch upstream
-> git branch --set-upstream-to=upstream/master master
+> git branch --set-upstream-to=upstream/main main
 > ```
 >
 > This will add the original repository as a "remote" called "upstream," Then
-> fetch the git information from that remote, then set your local `master`
-> branch to use the upstream master branch whenever you run `git pull`. Then you
-> can make all of your pull request branches based on this `master` branch.
-> Whenever you want to update your version of `master`, do a regular `git pull`.
+> fetch the git information from that remote, then set your local `main`
+> branch to use the upstream main branch whenever you run `git pull`. Then you
+> can make all of your pull request branches based on this `main` branch.
+> Whenever you want to update your version of `main`, do a regular `git pull`.
 
 ## Committing and Pushing changes
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     height="80"
     width="80"
     alt="tiger"
-    src="https://raw.githubusercontent.com/testing-library/cypress-testing-library/master/other/tiger.png"
+    src="https://raw.githubusercontent.com/testing-library/cypress-testing-library/main/other/tiger.png"
   />
 </a>
 
@@ -36,7 +36,7 @@ testing practices.</p>
     <img
       width="500"
       alt="TestingJavaScript.com Learn the smart, efficient way to test any JavaScript application."
-      src="https://raw.githubusercontent.com/testing-library/cypress-testing-library/master/other/testingjavascript.jpg"
+      src="https://raw.githubusercontent.com/testing-library/cypress-testing-library/main/other/testingjavascript.jpg"
     />
   </a>
 </div>
@@ -119,7 +119,7 @@ commands.
 [See the `DOM Testing Library` docs for reference](https://testing-library.com)
 
 You can find
-[all Library definitions here](https://github.com/testing-library/cypress-testing-library/tree/master/types/index.d.ts).
+[all Library definitions here](https://github.com/testing-library/cypress-testing-library/tree/main/types/index.d.ts).
 
 To configure DOM Testing Library, use the following custom command:
 
@@ -297,11 +297,11 @@ MIT
 [downloads-badge]: https://img.shields.io/npm/dm/@testing-library/cypress.svg?style=flat-square
 [npmtrends]: http://www.npmtrends.com/@testing-library/cypress
 [license-badge]: https://img.shields.io/npm/l/@testing-library/cypress.svg?style=flat-square
-[license]: https://github.com/testing-library/cypress-testing-library/blob/master/LICENSE
+[license]: https://github.com/testing-library/cypress-testing-library/blob/main/LICENSE
 [prs-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
 [prs]: http://makeapullrequest.com
 [coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
-[coc]: https://github.com/testing-library/cypress-testing-library/blob/master/other/CODE_OF_CONDUCT.md
+[coc]: https://github.com/testing-library/cypress-testing-library/blob/main/other/CODE_OF_CONDUCT.md
 [emojis]: https://allcontributors.org/docs/en/emoji-key
 [all-contributors]: https://github.com/all-contributors/all-contributors
 [all-contributors-badge]: https://img.shields.io/github/all-contributors/testing-library/cypress-testing-library?color=orange&style=flat-square

--- a/other/MAINTAINING.md
+++ b/other/MAINTAINING.md
@@ -61,7 +61,7 @@ to release. See the next section on Releases for more about that.
 
 ## Release
 
-Our releases are automatic. They happen whenever code lands into `master`. A
+Our releases are automatic. They happen whenever code lands into `main`. A
 GitHub Action gets kicked off and if it's successful, a tool called
 [`semantic-release`](https://github.com/semantic-release/semantic-release) is
 used to automatically publish a new release to npm as well as a changelog to


### PR DESCRIPTION

-->

as Git announced that main  should be your primary branch, I'm renaming all master references to main

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
