### PR TITLE
fix: allow cypress@8 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "@testing-library/dom": "^7.29.6"
   },
   "devDependencies": {
-    "cypress": "^6.0.1",
+    "cypress": "^8.0.0",
     "kcd-scripts": "^7.5.1",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
-    "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+    "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Allows Cypress 8.x to be used with this library.

<!-- Why are these changes necessary? -->

**Why**:
Cypress 8.0.0 was released today.

<!-- How were these changes implemented? -->

**How**:
Updates package.json to allow ^8.0.0 as a peer dependency. Also bumps the version of Cypress installed in development so tests and linting are run against the 8.x branch.  

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation (covered by existing documentation)
- [x] Tests (covered by existing tests)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
