### PR TITLE
fix: make chaining take precedence over surrounding `within` block.

### DIFF
--- a/cypress/fixtures/test-app/index.html
+++ b/cypress/fixtures/test-app/index.html
@@ -46,6 +46,9 @@
     <div id="nested">
       <h3>ByText within</h3>
       <button onclick="this.innerText = 'Button Clicked'">Button Text 2</button>
+      <div id="nested-twice">
+        <button onclick="this.innerText = 'Button Clicked'">Button Text 3</button>
+      </div>
     </div>
   </section>
   <section>

--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -28,7 +28,7 @@ describe('find* dom-testing-library commands', () => {
 
   it('findAllByText', () => {
     cy.findAllByText(/^Button Text \d$/)
-      .should('have.length', 2)
+      .should('have.length', 3)
       .click({multiple: true})
       .should('contain', 'Button Clicked')
   })
@@ -109,6 +109,13 @@ describe('find* dom-testing-library commands', () => {
     cy.get('#nested').within(() => {
       cy.findByText('Button Text 1').should('not.exist')
       cy.findByText('Button Text 2').should('exist')
+    })
+  })
+
+  it('findByText chain overrides within', () => {
+    cy.get('#nested').within(() => {
+      cy.get('#nested-twice').findByText('Button Text 2').should('not.exist')
+      cy.get('#nested-twice').findByText('Button Text 3').should('exist')
     })
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,14 +35,12 @@ function createCommand(queryName, implementationName) {
 
       const getSelector = () => `${queryName}(${queryArgument(args)})`
 
-      const win = cy.state('window')
-
       const consoleProps = {
         // TODO: Would be good to completely separate out the types of input into their own properties
         input: inputArr,
         Selector: getSelector(),
         'Applied To': getContainer(
-          options.container || prevSubject || win.document,
+          options.container || prevSubject,
         ),
       }
 
@@ -56,7 +54,7 @@ function createCommand(queryName, implementationName) {
       }
 
       const getValue = (
-        container = options.container || prevSubject || win.document,
+        container = options.container || prevSubject,
       ) => {
         const value = commandImpl(container)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,10 +7,11 @@ function getFirstElement(jqueryOrElement) {
 
 function getContainer(container) {
   const withinContainer = cy.state('withinSubject')
-  if (withinContainer) {
+  if (container === undefined && withinContainer) {
     return getFirstElement(withinContainer)
   }
-  return getFirstElement(container)
+
+  return getFirstElement(container || cy.state('window').document)
 }
 
 export {getFirstElement, getContainer}


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Chaining now takes precedence over the scope defined by its surrounding `within` block. Only calls that don't have a previous subject and don't have a container specified use the within block.

<!-- Why are these changes necessary? -->

**Why**: Chaining inside of a within block previously ignored the chain and searched starting at the `within` element. This gave incorrect (too many) results. This was touched on at the end of #132 

<!-- How were these changes implemented? -->

**How**: Moved the use of win.document inside of getContainer() so we can be more specific about when to use it.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
Yes
<!-- feel free to add additional comments -->
