### PR TITLE
Fixes #201: stop ignoring current subject when inside a .within

### DIFF
--- a/cypress/integration/find.spec.js
+++ b/cypress/integration/find.spec.js
@@ -119,6 +119,20 @@ describe('find* dom-testing-library commands', () => {
     })
   })
 
+  it('findByText inside within and with a previous subject', () => {
+    cy.get('section:nth-of-type(2)').within(() => {
+      cy.findByText(/Button Text 1/).should('exist')
+    })
+    cy.get('#nested')
+      .findByText(/Button Text/)
+      .should('exist')
+    cy.get('section:nth-of-type(2)').within(() => {
+      cy.get('#nested')
+        .findByText(/Button Text/)
+        .should('exist')
+    })
+  })
+
   it('findByText works when another page loads', () => {
     cy.findByText('Next Page').click()
     cy.findByText('New Page Loaded').should('exist')

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,8 +6,10 @@ function getFirstElement(jqueryOrElement) {
 }
 
 function getContainer(container) {
+  const subject = cy.state('subject')
   const withinContainer = cy.state('withinSubject')
-  if (withinContainer) {
+
+  if (!subject && withinContainer) {
     return getFirstElement(withinContainer)
   }
   return getFirstElement(container)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This PR updates the `getContainer` util to only fallback to the `withinSubject` if an explicit subject has not been yielded by the previous command.
<!-- Why are these changes necessary? -->

**Why**:
The following code fails without this change:
```html
  <section>
    <button>Button Text 1</button>
    <div id="nested">
      <button>Button Text 2</button>
    </div>
  </section>
```

```js
cy.get('section').within(() => {
  cy.get('#nested').findByText(/Button Text/).should('exist');
});
```
<!-- How were these changes implemented? -->

**How**:
I cloned the repo, added a new test case that failed, and then updated the util to fix the new test.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
