### PR TITLE
fix: remove deprecated cy.state('subject')

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ function getFirstElement(jqueryOrElement) {
 }
 
 function getContainer(container) {
-  const subject = cy.state('subject')
+  const subject = cy.currentSubject()
   const withinContainer = cy.state('withinSubject')
 
   if (!subject && withinContainer) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Replace `cy.state('subject')` by `cy.currentSubject()`.

<!-- Why are these changes necessary? -->

**Why**:

`cy.state('subject')` is being deprecated:

![image](https://user-images.githubusercontent.com/199648/188675815-1580efa4-83ee-4a68-b7cc-59ab61e5145a.png)


<!-- How were these changes implemented? -->

**How**:

Replace `cy.state('subject')` by `cy.currentSubject()` in `utils.ts`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
