### PR TITLE
fix: update Cypress' log bar with timeout information

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ function createCommand(queryName, implementationName) {
           type: prevSubject ? 'child' : 'parent',
           name: queryName,
           message: inputArr,
+          timeout: options.timeout,
           consoleProps: () => consoleProps,
         })
       }


### PR DESCRIPTION
Fixes #217
