### PR TITLE
Use Cypress.Commands.overwriteQuery when adding a command that already exists

### DIFF
--- a/src/__tests__/add-commands.js
+++ b/src/__tests__/add-commands.js
@@ -3,15 +3,41 @@ import {commands} from '../'
 test('adds commands to Cypress', () => {
   const addMock = jest.fn().mockName('Cypress.Commands.add')
   const addQueryMock = jest.fn().mockName('Cypress.Commands.addQuery')
-  global.Cypress = {Commands: {add: addMock, addQuery: addQueryMock}}
-  global.cy = {}
+  const overwriteQueryMock = jest
+    .fn()
+    .mockName('Cypress.Commands.overwriteQuery')
+  global.Cypress = {
+    Commands: {
+      add: addMock,
+      addQuery: addQueryMock,
+      overwriteQuery: overwriteQueryMock,
+    },
+  }
+  global.cy = {
+    findAllByLabelText: jest.fn(),
+  }
 
   require('../add-commands')
 
-  expect(addQueryMock).toHaveBeenCalledTimes(commands.length)
+  /** Commands that we're adding to the cy. namespace */
+  const newCommands = commands.filter(({name}) => !global.cy[name])
+  /** Commands that we're overwriting in the cy. namespace */
+  const overwrittenCommands = commands.filter(({name}) => global.cy[name])
+
+  expect(addQueryMock).toHaveBeenCalledTimes(newCommands.length)
+  expect(overwriteQueryMock).toHaveBeenCalledTimes(overwrittenCommands.length)
   expect(addMock).toHaveBeenCalledTimes(1) // we're also adding a configuration command
-  commands.forEach(({name}, index) => {
+
+  newCommands.forEach(({name}, index) => {
     expect(addQueryMock.mock.calls[index]).toMatchObject([
+      name,
+      // We get a new function that is `command.bind(null, cy)` i.e. global `cy` passed into the first argument.
+      // The commands themselves will be tested separately in the Cypress end-to-end tests.
+      expect.any(Function),
+    ])
+  })
+  overwrittenCommands.forEach(({name}, index) => {
+    expect(overwriteQueryMock.mock.calls[index]).toMatchObject([
       name,
       // We get a new function that is `command.bind(null, cy)` i.e. global `cy` passed into the first argument.
       // The commands themselves will be tested separately in the Cypress end-to-end tests.

--- a/src/add-commands.js
+++ b/src/add-commands.js
@@ -1,7 +1,11 @@
 import {configure, commands} from './'
 
 commands.forEach(({name, command}) => {
-  Cypress.Commands.addQuery(name, command)
+  if (cy[name]) {
+    Cypress.Commands.overwriteQuery(name, command)
+  } else {
+    Cypress.Commands.addQuery(name, command)
+  }
 })
 
 Cypress.Commands.add('configureCypressTestingLibrary', config => {


### PR DESCRIPTION
We're running to similar issues reported here https://github.com/testing-library/cypress-testing-library/pull/238

Some commands already exists in the Cypress namespace. To make this library future proof, I'm using the override API to override commands if Cypress adds similarly named commands to list of its commands. 

In our case we ran into issues for the `findAllByLabelText` command. 

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged

