### PR TITLE
Fix bug with cypress `testIsolation` option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function createQuery(queryName, implementationName) {
         Cypress.log({
           name: queryName,
           type:
-            this.get('prev') && this.get('prev').get('chainerId') === this.get('chainerId')
+            this.get('prev')?.get('chainerId') === this.get('chainerId')
               ? 'child'
               : 'parent',
           message: inputArr,

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function createQuery(queryName, implementationName) {
         Cypress.log({
           name: queryName,
           type:
-            this.get('prev').get('chainerId') === this.get('chainerId')
+            this.get('prev') && this.get('prev').get('chainerId') === this.get('chainerId')
               ? 'child'
               : 'parent',
           message: inputArr,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This fixes a bug where `this.get('prev')` returns undefined in some scenarios and the command `this.get('prev').get('chainerId')` throws an error since it's attempting to read `get` of `undefined`.
<!-- Why are these changes necessary? -->

**Why**:

There is more information about this issue here: https://github.com/testing-library/cypress-testing-library/issues/248, but several people have commented that they are experiencing this. @matt-vendia responded with a solution on that issue, which solves the problem for me too (along with others who thumbs-upped the comment).

**How**:

Make sure `this.get('prev')` exists before assuming it's an object.

**Checklist**:

- [ ] Documentation (n/a)
- [ ] Tests (n/a)
- [x] Ready to be merged

This change is safe and small enough that it is ready to be merged imo.