### PR TITLE
Add ability for users to supply generic type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,10 +35,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findByPlaceholderText(
+      findByPlaceholderText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -49,10 +49,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findAllByPlaceholderText(
+      findAllByPlaceholderText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -63,10 +63,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findByText(
+      findByText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: SelectorMatcherOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -77,10 +77,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findAllByText(
+      findAllByText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: SelectorMatcherOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -91,10 +91,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findByLabelText(
+      findByLabelText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: SelectorMatcherOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -105,10 +105,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findAllByLabelText(
+      findAllByLabelText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: SelectorMatcherOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -119,76 +119,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
-
-      /**
-       * dom-testing-library helpers for Cypress
-       *
-       * `findBy*` APIs search for an element and throw an error if nothing found
-       * `findAllBy*` APIs search for all elements and throw an error if nothing found
-       *
-       * @see https://github.com/testing-library/cypress-testing-library#usage
-       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
-       */
-      findAllByAltText(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
-
-      /**
-       * dom-testing-library helpers for Cypress
-       *
-       * `findBy*` APIs search for an element and throw an error if nothing found
-       * `findAllBy*` APIs search for all elements and throw an error if nothing found
-       *
-       * @see https://github.com/testing-library/cypress-testing-library#usage
-       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
-       */
-      findByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
-
-      /**
-       * dom-testing-library helpers for Cypress
-       *
-       * `findBy*` APIs search for an element and throw an error if nothing found
-       * `findAllBy*` APIs search for all elements and throw an error if nothing found
-       *
-       * @see https://github.com/testing-library/cypress-testing-library#usage
-       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
-       */
-      findAllByTestId(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
-
-      /**
-       * dom-testing-library helpers for Cypress
-       *
-       * `findBy*` APIs search for an element and throw an error if nothing found
-       * `findAllBy*` APIs search for all elements and throw an error if nothing found
-       *
-       * @see https://github.com/testing-library/cypress-testing-library#usage
-       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
-       */
-      findByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
-
-      /**
-       * dom-testing-library helpers for Cypress
-       *
-       * `findBy*` APIs search for an element and throw an error if nothing found
-       * `findAllBy*` APIs search for all elements and throw an error if nothing found
-       *
-       * @see https://github.com/testing-library/cypress-testing-library#usage
-       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
-       */
-      findAllByTitle(id: Matcher, options?: MatcherOptions): Chainable<JQuery>
-
-      /**
-       * dom-testing-library helpers for Cypress
-       *
-       * `findBy*` APIs search for an element and throw an error if nothing found
-       * `findAllBy*` APIs search for all elements and throw an error if nothing found
-       *
-       * @see https://github.com/testing-library/cypress-testing-library#usage
-       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
-       */
-      findByDisplayValue(
+      findByAltText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -199,10 +133,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findAllByDisplayValue(
+      findAllByAltText<E extends Node = HTMLElement>(
         id: Matcher,
         options?: MatcherOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -213,7 +147,10 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findByRole(id: ByRoleMatcher, options?: ByRoleOptions): Chainable<JQuery>
+      findByTestId<E extends Node = HTMLElement>(
+        id: Matcher,
+        options?: MatcherOptions,
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress
@@ -224,10 +161,94 @@ declare global {
        * @see https://github.com/testing-library/cypress-testing-library#usage
        * @see https://github.com/testing-library/dom-testing-library#table-of-contents
        */
-      findAllByRole(
+      findAllByTestId<E extends Node = HTMLElement>(
+        id: Matcher,
+        options?: MatcherOptions,
+      ): Chainable<JQuery<E>>
+
+      /**
+       * dom-testing-library helpers for Cypress
+       *
+       * `findBy*` APIs search for an element and throw an error if nothing found
+       * `findAllBy*` APIs search for all elements and throw an error if nothing found
+       *
+       * @see https://github.com/testing-library/cypress-testing-library#usage
+       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+       */
+      findByTitle<E extends Node = HTMLElement>(
+        id: Matcher,
+        options?: MatcherOptions,
+      ): Chainable<JQuery<E>>
+
+      /**
+       * dom-testing-library helpers for Cypress
+       *
+       * `findBy*` APIs search for an element and throw an error if nothing found
+       * `findAllBy*` APIs search for all elements and throw an error if nothing found
+       *
+       * @see https://github.com/testing-library/cypress-testing-library#usage
+       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+       */
+      findAllByTitle<E extends Node = HTMLElement>(
+        id: Matcher,
+        options?: MatcherOptions,
+      ): Chainable<JQuery<E>>
+
+      /**
+       * dom-testing-library helpers for Cypress
+       *
+       * `findBy*` APIs search for an element and throw an error if nothing found
+       * `findAllBy*` APIs search for all elements and throw an error if nothing found
+       *
+       * @see https://github.com/testing-library/cypress-testing-library#usage
+       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+       */
+      findByDisplayValue<E extends Node = HTMLElement>(
+        id: Matcher,
+        options?: MatcherOptions,
+      ): Chainable<JQuery<E>>
+
+      /**
+       * dom-testing-library helpers for Cypress
+       *
+       * `findBy*` APIs search for an element and throw an error if nothing found
+       * `findAllBy*` APIs search for all elements and throw an error if nothing found
+       *
+       * @see https://github.com/testing-library/cypress-testing-library#usage
+       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+       */
+      findAllByDisplayValue<E extends Node = HTMLElement>(
+        id: Matcher,
+        options?: MatcherOptions,
+      ): Chainable<JQuery<E>>
+
+      /**
+       * dom-testing-library helpers for Cypress
+       *
+       * `findBy*` APIs search for an element and throw an error if nothing found
+       * `findAllBy*` APIs search for all elements and throw an error if nothing found
+       *
+       * @see https://github.com/testing-library/cypress-testing-library#usage
+       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+       */
+      findByRole<E extends Node = HTMLElement>(
         id: ByRoleMatcher,
         options?: ByRoleOptions,
-      ): Chainable<JQuery>
+      ): Chainable<JQuery<E>>
+
+      /**
+       * dom-testing-library helpers for Cypress
+       *
+       * `findBy*` APIs search for an element and throw an error if nothing found
+       * `findAllBy*` APIs search for all elements and throw an error if nothing found
+       *
+       * @see https://github.com/testing-library/cypress-testing-library#usage
+       * @see https://github.com/testing-library/dom-testing-library#table-of-contents
+       */
+      findAllByRole<E extends Node = HTMLElement>(
+        id: ByRoleMatcher,
+        options?: ByRoleOptions,
+      ): Chainable<JQuery<E>>
 
       /**
        * dom-testing-library helpers for Cypress

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 import {configure} from '.'
- import './add-commands'
+import './add-commands'
 
 configure({testIdAttribute: 'data-myown-testid'})
 
@@ -13,6 +13,9 @@ cy.findByTestId('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 cy.findByTitle('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 cy.findByDisplayValue('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 cy.findByRole('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+// with types
+cy.findByLabelText<HTMLInputElement>('foo') // $ExpectType Chainable<JQuery<HTMLInputElement>>
+cy.findByRole<HTMLLinkElement>('link') // $ExpectType Chainable<JQuery<HTMLLinkElement>>
 
 // findAllBy*
 cy.findAllByPlaceholderText('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
@@ -23,6 +26,9 @@ cy.findAllByTestId('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 cy.findAllByTitle('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 cy.findAllByDisplayValue('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
 cy.findAllByRole('foo') // $ExpectType Chainable<JQuery<HTMLElement>>
+// with types
+cy.findAllByLabelText<HTMLInputElement>('foo') // $ExpectType Chainable<JQuery<HTMLInputElement>>
+cy.findAllByRole<HTMLLinkElement>('link') // $ExpectType Chainable<JQuery<HTMLLinkElement>>
 
 // configure
 cy.configureCypressTestingLibrary({testIdAttribute: 'data-myawesome-testid'}) // $ExpectType Chainable<void>

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,4 +1,14 @@
 {
   "extends": "../node_modules/kcd-scripts/shared-tsconfig.json",
-  "include": ["."]
+  "include": ["."],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add ability to supply generic types similar to Cypress's API

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->
This allows for further narrowing elements returned by queries in tests instead of just `HTMLElement` for every element

**How**:

<!-- Have you done all of these things?  -->
Update types

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
