### PR TITLE
fix: update testing-libary-dom to 9

### DIFF
--- a/cypress/e2e/find.cy.js
+++ b/cypress/e2e/find.cy.js
@@ -65,7 +65,7 @@ describe('find* dom-testing-library commands', () => {
   })
 
   it('findAllByRole', () => {
-    cy.findAllByRole(/^dialog/).should('have.length', 2)
+    cy.findAllByRole('dialog').should('have.length', 1)
   })
 
   it('findByTestId', () => {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.14.6",
-    "@testing-library/dom": "^8.1.0"
+    "@testing-library/dom": "^9.0.0"
   },
   "devDependencies": {
     "cypress": "^12.0.0",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Updating testing-library-dom to the latest version
<!-- Why are these changes necessary? -->

**Why**:
There were breaking changes in 8->9. Adding this library broke most of our existing jest tests because it requires `testing-library-dom^8.2.1`, but the latest `testing-library-react` requires `testing-library-dom^9.0.0`

<!-- How were these changes implemented? -->

**How**:
Updates the dependency and fixes a test failure caused by one of the breaking changes in testing-library-dom
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
