### PR TITLE
fix(deps): update cypress to version 14.0.0 and adjust peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "@testing-library/dom": "^10.1.0"
   },
   "devDependencies": {
-    "cypress": "^12.0.0",
+    "cypress": "^14.0.0",
     "kcd-scripts": "^11.2.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.3.5"
   },
   "peerDependencies": {
-    "cypress": "^12.0.0 || ^13.0.0"
+    "cypress": "^12.0.0 || ^13.0.0 || ^14.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: This adds Cypress 14 to the peer dependency and dev dependencies of this project.

<!-- Why are these changes necessary? -->

**Why**: The peer dependency change ensures that we can install Cypress 14 with npm without resorting to --legacy-peer-deps. The devDependencies change makes sure that we are actually testing against Cypress 14 and not a lower version.

<!-- How were these changes implemented? -->

**How**: I changed the numbers in the package.json, ran `npm i` and `npm run validate`. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation (N/A)
- [x] Tests (N/A)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Close #280 
