### PR TITLE
chore(package.json): Update to accomodate Cypress 15

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     strategy:
       matrix:
-        node: [18, 20]
+        node: [20]
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo

--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "@testing-library/dom": "^10.1.0"
   },
   "devDependencies": {
-    "cypress": "^14.0.0",
+    "cypress": "^15.0.0",
     "kcd-scripts": "^11.2.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.3.5"
   },
   "peerDependencies": {
-    "cypress": "^12.0.0 || ^13.0.0 || ^14.0.0"
+    "cypress": ">=12.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
Adds support for Cypress 15, which released on August 20th, 2025

What:

The update to the package json will prevent the issue of the peer dependencies throwing issues when cypress updates to 16 and beyond

Why:

How:

Checklist:

 Documentation
 Tests
 Ready to be merged