### PR TITLE
chore: update repository url protocol to git+https

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/testing-library/cypress-testing-library"
+    "url": "git+https://github.com/testing-library/cypress-testing-library.git"
   },
   "bugs": {
     "url": "https://github.com/testing-library/cypress-testing-library/issues"


### PR DESCRIPTION
**What**:

Change the repository url in `package.json` from:

`https://github.com/testing-library/cypress-testing-library`

to

`git+https://github.com/testing-library/cypress-testing-library.git`

**Why**:

- Closes https://github.com/testing-library/cypress-testing-library/issues/286, when the `release` job of the workflow [.github/workflows/validate.yml](https://github.com/testing-library/cypress-testing-library/blob/main/.github/workflows/validate.yml) runs, the logs show warnings, including:

> npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
> npm warn publish errors corrected:
> npm warn publish "repository.url" was normalized to "git+https://github.com/testing-library/cypress-testing-library.git"

**How**:

Using Ubuntu `24.04.3` LTS, Node.js `22.19.0` LTS, npm `10.9.3`, execute:

```shell
npm pkg fix
```

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
