### PR TITLE
ci: update validate workflow versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -41,7 +41,7 @@ jobs:
         run: npm run validate
 
       - name: ⬆️ Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
 
   release:
     needs: main
@@ -52,12 +52,12 @@ jobs:
       github.ref) && github.event_name == 'push' }}
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22 # Active LTS version
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
@@ -68,9 +68,9 @@ jobs:
         run: npm run build
 
       - name: 🚀 Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v5
         with:
-          semantic_version: 17
+          semantic_version: 24
           branches: |
             [
               '+([0-9])?(.{+([0-9]),x}).x',


### PR DESCRIPTION
**What**:

Update action versions:

| From                                                                                               | To                                                                                                 | `runs.using` |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------ |
| [actions/checkout@v2](https://github.com/actions/checkout/tree/v2)                                 | [actions/checkout@v5](https://github.com/actions/checkout/tree/v5)                                 | `node24`     |
| [actions/setup-node@v2](https://github.com/actions/setup-node/tree/v2)                             | [actions/setup-node@v4](https://github.com/actions/setup-node/tree/v4)                             | `node20`     |
| [codecov/codecov-action@v1](https://github.com/codecov/codecov-action/tree/v1)                     | [codecov/codecov-action@v5](https://github.com/codecov/codecov-action/tree/v5)                     | `composite`  |
| [cycjimmy/semantic-release-action@v2](https://github.com/cycjimmy/semantic-release-action/tree/v2) | [cycjimmy/semantic-release-action@v5](https://github.com/cycjimmy/semantic-release-action/tree/v5) | `node24`     |

and called dependency:

| From                                                                                     | To                                                                                               |
| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [semantic-release@17](https://github.com/semantic-release/semantic-release/tree/v17.4.7) | [semantic-release@24](https://github.com/semantic-release/semantic-release/releases/tag/v24.2.7) |

Update from Node.js 20 (Maintenance LTS) to Node.js 22 ([Active LTS](https://github.com/nodejs/Release/blob/main/README.md#release-schedule))

**Why**:

- Closes https://github.com/testing-library/cypress-testing-library/issues/288. [.github/workflows/validate.yml](https://github.com/testing-library/cypress-testing-library/blob/main/.github/workflows/validate.yml) is configured to use GitHub JavaScript actions that specify the use of the end-of-life Node.js version `node12`.
- Relates to issue https://github.com/testing-library/cypress-testing-library/issues/286. When the `release` job of the workflow [.github/workflows/validate.yml](https://github.com/testing-library/cypress-testing-library/blob/main/.github/workflows/validate.yml) is run, the logs show warnings, including:

---
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---
> [@octokit/request] "GET https://api.github.com/search/issues?q=repo%3Atesting-library%2Fcypress-testing-library+type%3Apr+is%3Amerged+e6ac1355982eb46508da4e2954213b7d274475a3" is deprecated. It is scheduled to be removed on Thu, 04 Sep 2025 00:00:00 GMT. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/


**How**:

Change the action versions defined in [.github/workflows/validate.yml](https://github.com/testing-library/cypress-testing-library/blob/main/.github/workflows/validate.yml)

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged

- Note that no coverage report is found. This is the same as before this PR and is an issue that would need to be investigated separately.
- Otherwise, I've tested this branch standalone as far as I can, also using `semantic-release` dry-run.